### PR TITLE
Supply info needed by the create invoice api

### DIFF
--- a/src/Payments.Mvc/Controllers/FilesApiController.cs
+++ b/src/Payments.Mvc/Controllers/FilesApiController.cs
@@ -60,6 +60,9 @@ namespace Payments.Mvc.Controllers
             {
                 success = true,
                 identifier,
+                file.FileName,
+                file.ContentType,
+                size = file.Length
             });
         }
     }


### PR DESCRIPTION
For attachments

{
  "success": true,
  "identifier": "1076xxxa80-Test--1-.txt",
  "fileName": "Test (1).txt",
  "contentType": "text/plain",
  "size": 32
}