### PR TITLE
Fix CSP Report

### DIFF
--- a/src/Payments.Mvc/Controllers/HomeController.cs
+++ b/src/Payments.Mvc/Controllers/HomeController.cs
@@ -123,9 +123,11 @@ namespace Payments.Mvc.Controllers
         [AllowAnonymous]
         [IgnoreAntiforgeryToken]
         [Route("csp-report")]
-        public IActionResult CspReport(CspReport model)
+        public IActionResult CspReport([FromBody]CspReportRequest model)
         {
-            Log.ForContext("report", model, true).Warning("csp-report");
+            if (model.CspReport != null) {
+                Log.ForContext("report", model.CspReport, true).Warning("csp-report");
+            }
 
             return new EmptyResult();
         }

--- a/src/Payments.Mvc/Models/CspReport.cs
+++ b/src/Payments.Mvc/Models/CspReport.cs
@@ -5,6 +5,12 @@ using System.Linq;
 
 namespace Payments.Mvc.Models
 {
+    public class CspReportRequest
+    {
+        [Newtonsoft.Json.JsonProperty("csp-report")]
+        public CspReport CspReport { get; set; }
+    }
+    
     public class CspReport
     {
         [JsonProperty("blocked-uri")]

--- a/src/Payments.Mvc/Startup.cs
+++ b/src/Payments.Mvc/Startup.cs
@@ -138,7 +138,7 @@ namespace Payments.Mvc
                             Log.Logger.Warning(args.ErrorContext.Error, "JSON Serialization Error: {message}", args.ErrorContext.Error.Message);
                         };
                     });
-                    
+
             services.AddDistributedMemoryCache();
             services.AddSession();
             services.AddCsp(nonceByteAmount: 32);
@@ -272,7 +272,13 @@ namespace Payments.Mvc
                 c.AllowScripts
                     .From("https://www.googletagmanager.com")
                     .From("https://www.google-analytics.com");
-;
+
+                c.AllowConnections.To("https://www.google-analytics.com");
+
+                if (Environment.IsDevelopment()) {
+                    c.AllowConnections.ToSelf(); // for HMR
+                }
+
                 c.AllowImages
                     .From("https://www.google-analytics.com");
 

--- a/src/Payments.Mvc/Startup.cs
+++ b/src/Payments.Mvc/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using AspNetCore.Security.CAS;
 using Joonasw.AspNetCore.SecurityHeaders;
@@ -11,6 +12,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.Routing.Constraints;
 using Microsoft.AspNetCore.SpaServices.Webpack;
@@ -118,7 +121,16 @@ namespace Payments.Mvc
             services.AddScoped<IAuthorizationHandler, VerifyTeamPermissionHandler>();
 
             // add application services
-            services.AddMvc()
+            services.AddMvc(options => {
+                // add the csp-report content type to that handled by the JsonInputFormatter
+                options
+                    .InputFormatters
+                    .Where(item => item.GetType() == typeof(JsonInputFormatter))
+                    .Cast<JsonInputFormatter>()
+                    .Single()
+                    .SupportedMediaTypes
+                    .Add("application/csp-report");
+            })
                 .AddJsonOptions((options) =>
                     {
                         options.SerializerSettings.Error += (sender, args) =>
@@ -126,6 +138,7 @@ namespace Payments.Mvc
                             Log.Logger.Warning(args.ErrorContext.Error, "JSON Serialization Error: {message}", args.ErrorContext.Error.Message);
                         };
                     });
+                    
             services.AddDistributedMemoryCache();
             services.AddSession();
             services.AddCsp(nonceByteAmount: 32);


### PR DESCRIPTION
CSP Report has always been broken -- the JSON format wasn't handled by the parser but more importantly the content-type for CSP reports isn't application/json so that requires modifying the default input formatter.