### PR TITLE
Don't specify StringComparison in EF queries

### DIFF
--- a/src/Payments.Mvc/Controllers/SearchController.cs
+++ b/src/Payments.Mvc/Controllers/SearchController.cs
@@ -37,7 +37,7 @@ namespace Payments.Mvc.Controllers
 
             if (q.Contains("@"))
             {
-                query = query.Where(a => a.CustomerEmail.Equals(q, StringComparison.OrdinalIgnoreCase));
+                query = query.Where(a => a.CustomerEmail == q);
             }
             else
             {


### PR DESCRIPTION
This was the only instance I found. All other uses of `StringComparison` are local.