### PR TITLE
Red Warning on details

### DIFF
--- a/src/Payments.Mvc/Views/Invoices/Details.cshtml
+++ b/src/Payments.Mvc/Views/Invoices/Details.cshtml
@@ -61,6 +61,12 @@
             </button>
         }
     </div>
+    @if(Model?.CalculatedTotal > 99999.99m)
+    {
+        <div class="alert alert-danger" role="alert">
+            <strong>Warning!</strong> The max amount the credit card will process is $99,999.99. Please use multiple invoices if a discount will not be used to lower the amount below this.
+        </div>
+    }
     <div class="card-body card-bot-border">
         @if (Model.Status == Invoice.StatusCodes.Draft || Model.Status == Invoice.StatusCodes.Sent)
         {


### PR DESCRIPTION
New warning on details (Second image already exists on edit page):
![image](https://github.com/ucdavis/payments/assets/469010/133d9cd6-f30e-4cf2-8c81-bab6917a24b9)

======== Second Image ==================

![image](https://github.com/ucdavis/payments/assets/469010/f2457363-fe2d-435b-a121-162903f4ed4c)
