### PR TITLE
Adds invoice type selection to teams

### DIFF
--- a/src/Payments.Mvc/ClientApp/src/css/_vendor.scss
+++ b/src/Payments.Mvc/ClientApp/src/css/_vendor.scss
@@ -104,12 +104,11 @@ input[type=number]::-webkit-outer-spin-button {
 
 // fix spacing on checkboxes
 .form-check {
-  padding-left: 2rem;
+    padding-left: 2rem;
 
-  .form-check-input {
-    margin-top: 0.6rem;
-    margin-left: -2rem;
-  }
+    .form-check-input {
+        margin-left: -2rem;
+    }
 }
 
 .progress-bar {

--- a/src/Payments.Mvc/Controllers/SettingsController.cs
+++ b/src/Payments.Mvc/Controllers/SettingsController.cs
@@ -134,12 +134,13 @@ namespace Payments.Mvc.Controllers
             team.ContactEmail = model.ContactEmail;
             team.ContactPhoneNumber = model.ContactPhoneNumber;
             team.WebHookApiKey = model.WebHookApiKey;
-            team.AllowedInvoiceType = model.AllowedInvoiceType;
+            
 
             // only admins can change active
             if (User.IsInRole(ApplicationRoleCodes.Admin))
             {
                 team.IsActive = model.IsActive;
+                team.AllowedInvoiceType = model.AllowedInvoiceType;
             }
 
             await _context.SaveChangesAsync();

--- a/src/Payments.Mvc/Controllers/SettingsController.cs
+++ b/src/Payments.Mvc/Controllers/SettingsController.cs
@@ -63,15 +63,15 @@ namespace Payments.Mvc.Controllers
 
             var model = new TeamDetailsModel
             {
-                Name               = team.Name,
-                Slug               = team.Slug,
-                ContactName        = team.ContactName,
-                ContactEmail       = team.ContactEmail,
+                Name = team.Name,
+                Slug = team.Slug,
+                ContactName = team.ContactName,
+                ContactEmail = team.ContactEmail,
                 ContactPhoneNumber = team.ContactPhoneNumber,
-                ApiKey             = userCanEdit ? team.ApiKey : "",
-                IsActive           = team.IsActive,
-                UserCanEdit        = userCanEdit,
-                WebHookApiKey      = team.WebHookApiKey
+                ApiKey = userCanEdit ? team.ApiKey : "",
+                IsActive = team.IsActive,
+                UserCanEdit = userCanEdit,
+                WebHookApiKey = team.WebHookApiKey
             };
 
             return View(model);
@@ -91,13 +91,14 @@ namespace Payments.Mvc.Controllers
 
             var model = new EditTeamViewModel()
             {
-                Name               = team.Name,
-                Slug               = team.Slug,
-                ContactName        = team.ContactName,
-                ContactEmail       = team.ContactEmail,
+                Name = team.Name,
+                Slug = team.Slug,
+                ContactName = team.ContactName,
+                ContactEmail = team.ContactEmail,
                 ContactPhoneNumber = team.ContactPhoneNumber,
-                IsActive           = team.IsActive,
-                WebHookApiKey      = team.WebHookApiKey
+                IsActive = team.IsActive,
+                WebHookApiKey = team.WebHookApiKey,
+                AllowedInvoiceType = team.AllowedInvoiceType
             };
 
             return View(model);
@@ -126,12 +127,13 @@ namespace Payments.Mvc.Controllers
                 return View(model);
             }
 
-            team.Name               = model.Name;
-            team.Slug               = model.Slug;
-            team.ContactName        = model.ContactName;
-            team.ContactEmail       = model.ContactEmail;
+            team.Name = model.Name;
+            team.Slug = model.Slug;
+            team.ContactName = model.ContactName;
+            team.ContactEmail = model.ContactEmail;
             team.ContactPhoneNumber = model.ContactPhoneNumber;
-            team.WebHookApiKey      = model.WebHookApiKey;
+            team.WebHookApiKey = model.WebHookApiKey;
+            team.AllowedInvoiceType = model.AllowedInvoiceType;
 
             // only admins can change active
             if (User.IsInRole(ApplicationRoleCodes.Admin))
@@ -165,14 +167,14 @@ namespace Payments.Mvc.Controllers
 
             var model = new TeamDetailsModel
             {
-                Name               = team.Name,
-                Slug               = team.Slug,
-                ContactName        = team.ContactName,
-                ContactEmail       = team.ContactEmail,
+                Name = team.Name,
+                Slug = team.Slug,
+                ContactName = team.ContactName,
+                ContactEmail = team.ContactEmail,
                 ContactPhoneNumber = team.ContactPhoneNumber,
-                IsActive           = team.IsActive,
-                Permissions        = permissions,
-                UserCanEdit        = userCanEdit
+                IsActive = team.IsActive,
+                Permissions = permissions,
+                UserCanEdit = userCanEdit
             };
 
             return View(model);
@@ -246,10 +248,10 @@ namespace Payments.Mvc.Controllers
                 {
                     var userToCreate = new User
                     {
-                        Email          = user.Mail,
-                        UserName       = user.Mail,
+                        Email = user.Mail,
+                        UserName = user.Mail,
                         CampusKerberos = user.Kerberos,
-                        Name           = user.FullName
+                        Name = user.FullName
                     };
 
                     var userPrincipal = new ClaimsPrincipal();
@@ -427,11 +429,11 @@ namespace Payments.Mvc.Controllers
             // create webhook and add it
             var webHook = new WebHook()
             {
-                Team               = team,
-                Url                = model.Url,
-                ContentType        = model.ContentType,
-                IsActive           = model.IsActive,
-                TriggerOnPaid      = model.TriggerOnPaid,
+                Team = team,
+                Url = model.Url,
+                ContentType = model.ContentType,
+                IsActive = model.IsActive,
+                TriggerOnPaid = model.TriggerOnPaid,
                 TriggerOnReconcile = model.TriggerOnReconcile,
             };
 
@@ -460,9 +462,9 @@ namespace Payments.Mvc.Controllers
 
             var model = new EditWebHookViewModel()
             {
-                Id            = webHook.Id,
-                Url           = webHook.Url,
-                IsActive      = webHook.IsActive,
+                Id = webHook.Id,
+                Url = webHook.Url,
+                IsActive = webHook.IsActive,
                 TriggerOnPaid = webHook.TriggerOnPaid,
             };
 
@@ -494,10 +496,10 @@ namespace Payments.Mvc.Controllers
             }
 
             // update model
-            webHook.Url                = model.Url;
-            webHook.ContentType        = model.ContentType;
-            webHook.IsActive           = model.IsActive;
-            webHook.TriggerOnPaid      = model.TriggerOnPaid;
+            webHook.Url = model.Url;
+            webHook.ContentType = model.ContentType;
+            webHook.IsActive = model.IsActive;
+            webHook.TriggerOnPaid = model.TriggerOnPaid;
             webHook.TriggerOnReconcile = model.TriggerOnReconcile;
 
             await _context.SaveChangesAsync();

--- a/src/Payments.Mvc/Controllers/SettingsController.cs
+++ b/src/Payments.Mvc/Controllers/SettingsController.cs
@@ -71,7 +71,8 @@ namespace Payments.Mvc.Controllers
                 ApiKey = userCanEdit ? team.ApiKey : "",
                 IsActive = team.IsActive,
                 UserCanEdit = userCanEdit,
-                WebHookApiKey = team.WebHookApiKey
+                WebHookApiKey = team.WebHookApiKey,
+                AllowedInvoiceType = team.AllowedInvoiceType
             };
 
             return View(model);

--- a/src/Payments.Mvc/Controllers/TeamsController.cs
+++ b/src/Payments.Mvc/Controllers/TeamsController.cs
@@ -65,18 +65,19 @@ namespace Payments.Mvc.Controllers
             if (!ModelState.IsValid)
             {
                 return View(model);
-            }            
+            }
 
             var team = new Team()
             {
-                Name               = model.Name,
-                Slug               = model.Slug,
-                ContactName        = model.ContactName,
-                ContactEmail       = model.ContactEmail,
+                Name = model.Name,
+                Slug = model.Slug,
+                ContactName = model.ContactName,
+                ContactEmail = model.ContactEmail,
                 ContactPhoneNumber = model.ContactPhoneNumber,
-                IsActive           = true,
-                ApiKey             = Guid.NewGuid().ToString("N").ToUpper(),
-                WebHookApiKey      = model.WebHookApiKey,
+                IsActive = true,
+                ApiKey = Guid.NewGuid().ToString("N").ToUpper(),
+                WebHookApiKey = model.WebHookApiKey,
+                AllowedInvoiceType = model.AllowedInvoiceType,
             };
 
             // add user to team

--- a/src/Payments.Mvc/Models/TeamViewModels/BaseTeamViewModel.cs
+++ b/src/Payments.Mvc/Models/TeamViewModels/BaseTeamViewModel.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel.DataAnnotations;
+using static Payments.Core.Domain.Team;
 
 namespace Payments.Mvc.Models.TeamViewModels
 {
@@ -38,5 +39,10 @@ namespace Payments.Mvc.Models.TeamViewModels
         [Display(Name = "WebHook API Key")]
         [RegularExpression(@"^[a-zA-Z0-9\-._~]*$", ErrorMessage = "WebHook API Key may only contain URL-safe characters. (a-z A-Z 0-9 - . _ ~)")]
         public string WebHookApiKey { get; set; }
+
+        [Required]
+        [StringLength(10)]
+        [Display(Name = "Allowed Invoice Type")]
+        public string AllowedInvoiceType { get; set; } = AllowedInvoiceTypes.CreditCard;
     }
 }

--- a/src/Payments.Mvc/Models/TeamViewModels/TeamDetailsModel.cs
+++ b/src/Payments.Mvc/Models/TeamViewModels/TeamDetailsModel.cs
@@ -30,6 +30,9 @@ namespace Payments.Mvc.Models.TeamViewModels
         [Display(Name = "Active?")]
         public bool IsActive { get; set; }
 
+        [Display(Name = "Allowed Invoice Type")]
+        public string AllowedInvoiceType { get; set; }
+
         public IList<FinancialAccount> Accounts { get; set; }
 
         public IList<TeamPermission> Permissions { get; set; }

--- a/src/Payments.Mvc/Views/Settings/Edit.cshtml
+++ b/src/Payments.Mvc/Views/Settings/Edit.cshtml
@@ -50,37 +50,69 @@
                         </div>
                     </div>
 
-                    <div class="form-group">
-                        <label asp-for="AllowedInvoiceType" class="control-label"></label>
-                        <div class="ms-3">
-                            <div class="form-check d-flex">
-                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                    value="@Team.AllowedInvoiceTypes.CreditCard" />
-                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Credit Card
-                                    Only</label>
-                            </div>
-                            <div class="form-check d-flex">
-                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                    value="@Team.AllowedInvoiceTypes.Recharge" />
-                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Recharge Only</label>
-                            </div>
-                            <div class="form-check d-flex">
-                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                    value="@Team.AllowedInvoiceTypes.Both" />
-                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Both</label>
-                            </div>
-                        </div>
-                        <span asp-validation-for="AllowedInvoiceType" class="text-danger"></span>
-                    </div>
+
 
                     @if (User.IsInRole(ApplicationRoleCodes.Admin))
                     {
+                        <div class="form-group">
+                            <label asp-for="AllowedInvoiceType" class="control-label"></label>
+                            <div class="ms-3">
+                                <div class="form-check d-flex">
+                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                        value="@Team.AllowedInvoiceTypes.CreditCard" />
+                                    <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">
+                                        Credit Card
+                                        Only
+                                    </label>
+                                </div>
+                                <div class="form-check d-flex">
+                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                        value="@Team.AllowedInvoiceTypes.Recharge" />
+                                    <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Recharge Only</label>
+                                </div>
+                                <div class="form-check d-flex">
+                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                        value="@Team.AllowedInvoiceTypes.Both" />
+                                    <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Both</label>
+                                </div>
+                            </div>
+                            <span asp-validation-for="AllowedInvoiceType" class="text-danger"></span>
+                        </div>
+
+
                         <div class="form-group">
                             <div class="checkbox">
                                 <label>
                                     <input asp-for="IsActive" /> @Html.DisplayNameFor(model => model.IsActive)
                                 </label>
                             </div>
+                        </div>
+                    }
+                    else
+                    {
+                        <div class="form-group">
+                            <label asp-for="AllowedInvoiceType" class="control-label"></label>
+                            <div class="ms-3">
+                                <div class="form-check d-flex">
+                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                        value="@Team.AllowedInvoiceTypes.CreditCard" disabled />
+                                    <label class="form-check-label ms-2 text-muted">
+                                        Credit Card Only
+                                    </label>
+                                </div>
+                                <div class="form-check d-flex">
+                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                        value="@Team.AllowedInvoiceTypes.Recharge" disabled />
+                                    <label class="form-check-label ms-2 text-muted">Recharge Only</label>
+                                </div>
+                                <div class="form-check d-flex">
+                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                        value="@Team.AllowedInvoiceTypes.Both" disabled />
+                                    <label class="form-check-label ms-2 text-muted">Both</label>
+                                </div>
+                            </div>
+                            <div class="text-muted small mt-1">If you need to change the allowed invoice type, please submit
+                                a help ticket.</div>
                         </div>
                     }
 

--- a/src/Payments.Mvc/Views/Settings/Edit.cshtml
+++ b/src/Payments.Mvc/Views/Settings/Edit.cshtml
@@ -53,18 +53,18 @@
                     <div class="form-group">
                         <label asp-for="AllowedInvoiceType" class="control-label"></label>
                         <div class="ms-3">
-                            <div class="form-check d-flex align-items-center">
+                            <div class="form-check d-flex">
                                 <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
                                     value="@Team.AllowedInvoiceTypes.CreditCard" />
                                 <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Credit Card
                                     Only</label>
                             </div>
-                            <div class="form-check d-flex align-items-center">
+                            <div class="form-check d-flex">
                                 <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
                                     value="@Team.AllowedInvoiceTypes.Recharge" />
                                 <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Recharge Only</label>
                             </div>
-                            <div class="form-check d-flex align-items-center">
+                            <div class="form-check d-flex">
                                 <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
                                     value="@Team.AllowedInvoiceTypes.Both" />
                                 <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Both</label>

--- a/src/Payments.Mvc/Views/Settings/Edit.cshtml
+++ b/src/Payments.Mvc/Views/Settings/Edit.cshtml
@@ -1,4 +1,5 @@
 @using Payments.Mvc.Models.Roles
+@using Payments.Core.Domain
 @model Payments.Mvc.Models.TeamViewModels.EditTeamViewModel
 
 @{
@@ -45,7 +46,31 @@
                         <label asp-for="WebHookApiKey" class="control-label"></label>
                         <input asp-for="WebHookApiKey" class="form-control" />
                         <span asp-validation-for="WebHookApiKey" class="text-danger"></span>
-                        <div class="text-muted">Leave blank if you don't want to pass authorization to your webhook URL</div>
+                        <div class="text-muted">Leave blank if you don't want to pass authorization to your webhook URL
+                        </div>
+                    </div>
+
+                    <div class="form-group">
+                        <label asp-for="AllowedInvoiceType" class="control-label"></label>
+                        <div class="ms-3">
+                            <div class="form-check d-flex align-items-center">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.CreditCard" />
+                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Credit Card
+                                    Only</label>
+                            </div>
+                            <div class="form-check d-flex align-items-center">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.Recharge" />
+                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Recharge Only</label>
+                            </div>
+                            <div class="form-check d-flex align-items-center">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.Both" />
+                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Both</label>
+                            </div>
+                        </div>
+                        <span asp-validation-for="AllowedInvoiceType" class="text-danger"></span>
                     </div>
 
                     @if (User.IsInRole(ApplicationRoleCodes.Admin))

--- a/src/Payments.Mvc/Views/Settings/Edit.cshtml
+++ b/src/Payments.Mvc/Views/Settings/Edit.cshtml
@@ -50,69 +50,46 @@
                         </div>
                     </div>
 
+                    @{
+                        bool isAdmin = User.IsInRole(ApplicationRoleCodes.Admin);
+                        string labelClass = isAdmin ? "form-check-label ms-2" : "form-check-label ms-2 text-muted";
+                    }
 
-
-                    @if (User.IsInRole(ApplicationRoleCodes.Admin))
-                    {
-                        <div class="form-group">
-                            <label asp-for="AllowedInvoiceType" class="control-label"></label>
-                            <div class="ms-3">
-                                <div class="form-check d-flex">
-                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                        value="@Team.AllowedInvoiceTypes.CreditCard" />
-                                    <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">
-                                        Credit Card
-                                        Only
-                                    </label>
-                                </div>
-                                <div class="form-check d-flex">
-                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                        value="@Team.AllowedInvoiceTypes.Recharge" />
-                                    <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Recharge Only</label>
-                                </div>
-                                <div class="form-check d-flex">
-                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                        value="@Team.AllowedInvoiceTypes.Both" />
-                                    <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Both</label>
-                                </div>
+                    <div class="form-group">
+                        <label asp-for="AllowedInvoiceType" class="control-label"></label>
+                        <div class="ms-3">
+                            <div class="form-check d-flex">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.CreditCard" disabled="@(!isAdmin)" />
+                                <label class="@labelClass" asp-for="AllowedInvoiceType">Credit Card Only</label>
                             </div>
-                            <span asp-validation-for="AllowedInvoiceType" class="text-danger"></span>
+                            <div class="form-check d-flex">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.Recharge" disabled="@(!isAdmin)" />
+                                <label class="@labelClass" asp-for="AllowedInvoiceType">Recharge Only</label>
+                            </div>
+                            <div class="form-check d-flex">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.Both" disabled="@(!isAdmin)" />
+                                <label class="@labelClass" asp-for="AllowedInvoiceType">Both</label>
+                            </div>
                         </div>
+                        @if (!isAdmin)
+                        {
+                            <div class="text-muted small mt-1">If you need to change the allowed invoice type, please submit
+                                a help ticket.</div>
+                        }
+                        <span asp-validation-for="AllowedInvoiceType" class="text-danger"></span>
+                    </div>
 
-
+                    @if (isAdmin)
+                    {
                         <div class="form-group">
                             <div class="checkbox">
                                 <label>
                                     <input asp-for="IsActive" /> @Html.DisplayNameFor(model => model.IsActive)
                                 </label>
                             </div>
-                        </div>
-                    }
-                    else
-                    {
-                        <div class="form-group">
-                            <label asp-for="AllowedInvoiceType" class="control-label"></label>
-                            <div class="ms-3">
-                                <div class="form-check d-flex">
-                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                        value="@Team.AllowedInvoiceTypes.CreditCard" disabled />
-                                    <label class="form-check-label ms-2 text-muted">
-                                        Credit Card Only
-                                    </label>
-                                </div>
-                                <div class="form-check d-flex">
-                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                        value="@Team.AllowedInvoiceTypes.Recharge" disabled />
-                                    <label class="form-check-label ms-2 text-muted">Recharge Only</label>
-                                </div>
-                                <div class="form-check d-flex">
-                                    <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
-                                        value="@Team.AllowedInvoiceTypes.Both" disabled />
-                                    <label class="form-check-label ms-2 text-muted">Both</label>
-                                </div>
-                            </div>
-                            <div class="text-muted small mt-1">If you need to change the allowed invoice type, please submit
-                                a help ticket.</div>
                         </div>
                     }
 

--- a/src/Payments.Mvc/Views/Settings/Index.cshtml
+++ b/src/Payments.Mvc/Views/Settings/Index.cshtml
@@ -41,7 +41,7 @@
                         @Html.DisplayNameFor(model => model.WebHookApiKey)
                     </dt>
                     <dd>
-                        @if(!string.IsNullOrWhiteSpace(Model.WebHookApiKey))
+                        @if (!string.IsNullOrWhiteSpace(Model.WebHookApiKey))
                         {
                             @Html.DisplayFor(model => model.WebHookApiKey)
                         }
@@ -70,6 +70,36 @@
                 </dt>
                 <dd>
                     @Html.DisplayFor(model => model.ContactPhoneNumber)
+                </dd>
+                <dt>
+                    @Html.DisplayNameFor(model => model.AllowedInvoiceType)
+                </dt>
+                <dd>
+                    @{
+                        string displayText = "";
+                        string badgeClass = "";
+
+                        switch (Model.AllowedInvoiceType)
+                        {
+                            case "CC":
+                                displayText = "Credit Card Only";
+                                badgeClass = "badge bg-primary";
+                                break;
+                            case "Recharge":
+                                displayText = "Recharge Only";
+                                badgeClass = "badge bg-success";
+                                break;
+                            case "Both":
+                                displayText = "Both Credit Card and Recharge";
+                                badgeClass = "badge bg-info";
+                                break;
+                            default:
+                                displayText = Model.AllowedInvoiceType;
+                                badgeClass = "badge bg-secondary";
+                                break;
+                        }
+                    }
+                    <span class="@badgeClass">@displayText</span>
                 </dd>
             </dl>
         </div>

--- a/src/Payments.Mvc/Views/Teams/Create.cshtml
+++ b/src/Payments.Mvc/Views/Teams/Create.cshtml
@@ -52,17 +52,18 @@
                     <div class="form-group">
                         <label asp-for="AllowedInvoiceType" class="control-label"></label>
                         <div class="ms-3">
-                            <div class="form-check d-flex align-items-center">
+                            <div class="form-check d-flex">
                                 <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
                                     value="@Team.AllowedInvoiceTypes.CreditCard" checked />
-                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Credit Card Only</label>
+                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Credit Card
+                                    Only</label>
                             </div>
-                            <div class="form-check d-flex align-items-center">
+                            <div class="form-check d-flex">
                                 <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
                                     value="@Team.AllowedInvoiceTypes.Recharge" />
                                 <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Recharge Only</label>
                             </div>
-                            <div class="form-check d-flex align-items-center">
+                            <div class="form-check d-flex">
                                 <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
                                     value="@Team.AllowedInvoiceTypes.Both" />
                                 <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Both</label>

--- a/src/Payments.Mvc/Views/Teams/Create.cshtml
+++ b/src/Payments.Mvc/Views/Teams/Create.cshtml
@@ -1,4 +1,5 @@
 @using Payments.Mvc.Models.TeamViewModels
+@using Payments.Core.Domain
 @model CreateTeamViewModel
 
 @{
@@ -45,7 +46,29 @@
                         <label asp-for="WebHookApiKey" class="control-label"></label>
                         <input asp-for="WebHookApiKey" class="form-control" />
                         <span asp-validation-for="WebHookApiKey" class="text-danger"></span>
-                        <span class="text-muted">Leave blank if you don't want to pass authorization to your webhook URL</span>
+                        <span class="text-muted">Leave blank if you don't want to pass authorization to your webhook
+                            URL</span>
+                    </div>
+                    <div class="form-group">
+                        <label asp-for="AllowedInvoiceType" class="control-label"></label>
+                        <div class="ms-3">
+                            <div class="form-check d-flex align-items-center">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.CreditCard" checked />
+                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Credit Card Only</label>
+                            </div>
+                            <div class="form-check d-flex align-items-center">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.Recharge" />
+                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Recharge Only</label>
+                            </div>
+                            <div class="form-check d-flex align-items-center">
+                                <input asp-for="AllowedInvoiceType" class="form-check-input" type="radio"
+                                    value="@Team.AllowedInvoiceTypes.Both" />
+                                <label class="form-check-label ms-2" asp-for="AllowedInvoiceType">Both</label>
+                            </div>
+                        </div>
+                        <span asp-validation-for="AllowedInvoiceType" class="text-danger"></span>
                     </div>
                     <div class="form-group">
                         <input type="submit" value="Create" class="btn" />


### PR DESCRIPTION
Adds the ability to select allowed invoice types for teams, enabling control over payment methods.

This change introduces a radio button selection in the team creation and settings edit views, allowing admins to specify whether a team can accept Credit Card payments, Recharge payments, or both.