### PR TITLE
Replaces button-group with toggle for invoice type

### DIFF
--- a/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
@@ -226,31 +226,89 @@ export default class CreateInvoiceContainer extends React.Component<
       return null;
     }
 
+    const toggleContainerStyle: React.CSSProperties = {
+      display: 'flex',
+      justifyContent: 'flex-start',
+      margin: '10px 0'
+    };
+
+    const toggleStyle: React.CSSProperties = {
+      position: 'relative',
+      display: 'flex',
+      backgroundColor: '#f8f9fa',
+      border: '2px solid #dee2e6',
+      borderRadius: '25px',
+      cursor: 'pointer',
+      width: '280px',
+      height: '50px',
+      transition: 'all 0.3s ease',
+      overflow: 'hidden'
+    };
+
+    const toggleOptionStyle: React.CSSProperties = {
+      flex: 1,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      position: 'relative',
+      zIndex: 2,
+      transition: 'color 0.3s ease',
+      fontWeight: 500,
+      color: '#6c757d'
+    };
+
+    const activeOptionStyle: React.CSSProperties = {
+      ...toggleOptionStyle,
+      color: 'white'
+    };
+
+    const sliderStyle: React.CSSProperties = {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: '50%',
+      height: '100%',
+      background: 'linear-gradient(135deg, #007bff, #0056b3)',
+      borderRadius: '23px',
+      transition: 'transform 0.3s ease',
+      zIndex: 1,
+      boxShadow: '0 2px 4px rgba(0,123,255,0.3)',
+      transform:
+        invoiceType === 'Recharge' ? 'translateX(100%)' : 'translateX(0%)'
+    };
+
     return (
       <div className='card-body invoice-type'>
         <h2>Invoice Type</h2>
         <div className='form-group'>
-          <div className='btn-group' role='group' aria-label='Invoice Type'>
-            <button
-              type='button'
-              className={`btn ${
-                invoiceType === 'CC' ? 'btn-primary' : 'btn-outline-primary'
-              }`}
-              onClick={() => this.updateProperty('invoiceType', 'CC')}
+          <div style={toggleContainerStyle}>
+            <div
+              style={toggleStyle}
+              onClick={() =>
+                this.updateProperty(
+                  'invoiceType',
+                  invoiceType === 'CC' ? 'Recharge' : 'CC'
+                )
+              }
             >
-              Credit Card
-            </button>
-            <button
-              type='button'
-              className={`btn ${
-                invoiceType === 'Recharge'
-                  ? 'btn-primary'
-                  : 'btn-outline-primary'
-              }`}
-              onClick={() => this.updateProperty('invoiceType', 'Recharge')}
-            >
-              Recharge
-            </button>
+              <div
+                style={
+                  invoiceType === 'CC' ? activeOptionStyle : toggleOptionStyle
+                }
+              >
+                <span>Credit Card</span>
+              </div>
+              <div
+                style={
+                  invoiceType === 'Recharge'
+                    ? activeOptionStyle
+                    : toggleOptionStyle
+                }
+              >
+                <span>Recharge</span>
+              </div>
+              <div style={sliderStyle}></div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
@@ -226,64 +226,13 @@ export default class CreateInvoiceContainer extends React.Component<
       return null;
     }
 
-    const toggleContainerStyle: React.CSSProperties = {
-      display: 'flex',
-      justifyContent: 'flex-start',
-      margin: '10px 0'
-    };
-
-    const toggleStyle: React.CSSProperties = {
-      position: 'relative',
-      display: 'flex',
-      backgroundColor: '#f8f9fa',
-      border: '2px solid #dee2e6',
-      borderRadius: '25px',
-      cursor: 'pointer',
-      width: '280px',
-      height: '50px',
-      transition: 'all 0.3s ease',
-      overflow: 'hidden'
-    };
-
-    const toggleOptionStyle: React.CSSProperties = {
-      flex: 1,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      position: 'relative',
-      zIndex: 2,
-      transition: 'color 0.3s ease',
-      fontWeight: 500,
-      color: '#6c757d'
-    };
-
-    const activeOptionStyle: React.CSSProperties = {
-      ...toggleOptionStyle,
-      color: 'white !important' as any
-    };
-
-    const sliderStyle: React.CSSProperties = {
-      position: 'absolute',
-      top: 0,
-      left: 0,
-      width: '50%',
-      height: '100%',
-      background: '#1d4a83',
-      borderRadius: '23px',
-      transition: 'transform 0.3s ease',
-      zIndex: 1,
-      boxShadow: '0 2px 4px rgba(29,74,131,0.3)',
-      transform:
-        invoiceType === 'Recharge' ? 'translateX(100%)' : 'translateX(0%)'
-    };
-
     return (
       <div className='card-body invoice-type'>
         <h2>Invoice Type</h2>
         <div className='form-group'>
-          <div style={toggleContainerStyle}>
+          <div className='invoice-type-toggle-container'>
             <div
-              style={toggleStyle}
+              className='invoice-type-toggle'
               onClick={() =>
                 this.updateProperty(
                   'invoiceType',
@@ -292,32 +241,24 @@ export default class CreateInvoiceContainer extends React.Component<
               }
             >
               <div
-                style={
-                  invoiceType === 'CC' ? activeOptionStyle : toggleOptionStyle
-                }
+                className={`invoice-type-toggle-option ${
+                  invoiceType === 'CC' ? 'active' : ''
+                }`}
               >
-                <span
-                  style={{ color: invoiceType === 'CC' ? 'white' : '#6c757d' }}
-                >
-                  Credit Card
-                </span>
+                <span>Credit Card</span>
               </div>
               <div
-                style={
-                  invoiceType === 'Recharge'
-                    ? activeOptionStyle
-                    : toggleOptionStyle
-                }
+                className={`invoice-type-toggle-option ${
+                  invoiceType === 'Recharge' ? 'active' : ''
+                }`}
               >
-                <span
-                  style={{
-                    color: invoiceType === 'Recharge' ? 'white' : '#6c757d'
-                  }}
-                >
-                  Recharge
-                </span>
+                <span>Recharge</span>
               </div>
-              <div style={sliderStyle}></div>
+              <div
+                className={`invoice-type-toggle-slider ${
+                  invoiceType === 'Recharge' ? 'slide-right' : 'slide-left'
+                }`}
+              ></div>
             </div>
           </div>
         </div>

--- a/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
@@ -259,7 +259,7 @@ export default class CreateInvoiceContainer extends React.Component<
 
     const activeOptionStyle: React.CSSProperties = {
       ...toggleOptionStyle,
-      color: 'white'
+      color: 'white !important' as any
     };
 
     const sliderStyle: React.CSSProperties = {
@@ -268,11 +268,11 @@ export default class CreateInvoiceContainer extends React.Component<
       left: 0,
       width: '50%',
       height: '100%',
-      background: 'linear-gradient(135deg, #007bff, #0056b3)',
+      background: '#1d4a83',
       borderRadius: '23px',
       transition: 'transform 0.3s ease',
       zIndex: 1,
-      boxShadow: '0 2px 4px rgba(0,123,255,0.3)',
+      boxShadow: '0 2px 4px rgba(29,74,131,0.3)',
       transform:
         invoiceType === 'Recharge' ? 'translateX(100%)' : 'translateX(0%)'
     };
@@ -296,7 +296,11 @@ export default class CreateInvoiceContainer extends React.Component<
                   invoiceType === 'CC' ? activeOptionStyle : toggleOptionStyle
                 }
               >
-                <span>Credit Card</span>
+                <span
+                  style={{ color: invoiceType === 'CC' ? 'white' : '#6c757d' }}
+                >
+                  Credit Card
+                </span>
               </div>
               <div
                 style={
@@ -305,7 +309,13 @@ export default class CreateInvoiceContainer extends React.Component<
                     : toggleOptionStyle
                 }
               >
-                <span>Recharge</span>
+                <span
+                  style={{
+                    color: invoiceType === 'Recharge' ? 'white' : '#6c757d'
+                  }}
+                >
+                  Recharge
+                </span>
               </div>
               <div style={sliderStyle}></div>
             </div>

--- a/src/Payments.Mvc/ClientApp/src/css/_components.scss
+++ b/src/Payments.Mvc/ClientApp/src/css/_components.scss
@@ -494,3 +494,73 @@ pre[class*='language-'] {
 .token.entity {
   cursor: help;
 }
+
+// Invoice Type Toggle Styles
+.invoice-type-toggle-container {
+  display: flex;
+  justify-content: flex-start;
+  margin: 10px 0;
+}
+
+.invoice-type-toggle {
+  position: relative;
+  display: flex;
+  background-color: #f8f9fa;
+  border: 2px solid #dee2e6;
+  border-radius: 25px;
+  cursor: pointer;
+  width: 280px;
+  height: 50px;
+  transition: all 0.3s ease;
+  overflow: hidden;
+
+  &:hover {
+    border-color: $primary-color;
+  }
+}
+
+.invoice-type-toggle-option {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  z-index: 2;
+  transition: color 0.3s ease;
+  font-weight: 500;
+  color: #6c757d;
+
+  span {
+    color: #6c757d;
+    transition: color 0.3s ease;
+  }
+
+  &.active {
+    color: white !important;
+    
+    span {
+      color: white !important;
+    }
+  }
+}
+
+.invoice-type-toggle-slider {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 50%;
+  height: 100%;
+  background: $primary-color;
+  border-radius: 23px;
+  transition: transform 0.3s ease;
+  z-index: 1;
+  box-shadow: 0 2px 4px rgba(29, 74, 131, 0.3);
+
+  &.slide-right {
+    transform: translateX(100%);
+  }
+
+  &.slide-left {
+    transform: translateX(0%);
+  }
+}


### PR DESCRIPTION
Replaces the Bootstrap button-group used for selecting the invoice type with a custom-styled toggle component.

This provides a more modern and visually appealing user interface for choosing between "Credit Card" and "Recharge" invoice types.