### PR TITLE
Adds invoice type validation

### DIFF
--- a/src/Payments.Core/Attributes/ValidInvoiceTypeAttribute.cs
+++ b/src/Payments.Core/Attributes/ValidInvoiceTypeAttribute.cs
@@ -1,0 +1,31 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using Payments.Core.Domain;
+
+namespace Payments.Core.Attributes
+{
+    /// <summary>
+    /// Validates that the invoice type is one of the valid invoice types defined in Invoice.InvoiceTypes
+    /// </summary>
+    public class ValidInvoiceTypeAttribute : ValidationAttribute
+    {
+        public override bool IsValid(object value)
+        {
+            if (value == null)
+            {
+                return false; // Required attribute should handle null values
+            }
+
+            var stringValue = value.ToString();
+
+            // Check against the constants defined in Invoice.InvoiceTypes
+            return stringValue == Invoice.InvoiceTypes.CreditCard ||
+                   stringValue == Invoice.InvoiceTypes.Recharge;
+        }
+
+        public override string FormatErrorMessage(string name)
+        {
+            return $"The {name} field must be either '{Invoice.InvoiceTypes.CreditCard}' or '{Invoice.InvoiceTypes.Recharge}'.";
+        }
+    }
+}

--- a/src/Payments.Core/Models/Invoice/CreateInvoiceModel.cs
+++ b/src/Payments.Core/Models/Invoice/CreateInvoiceModel.cs
@@ -1,4 +1,5 @@
 using Payments.Core.Domain;
+using Payments.Core.Attributes;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
@@ -48,6 +49,11 @@ namespace Payments.Core.Models.Invoice
 
         public IList<RechargeAccount> RechargeAccounts { get; set; } = new List<RechargeAccount>();
 
+        /// <summary>
+        /// Invoice type - must be either "CC" (Credit Card) or "Recharge"
+        /// </summary>
+        [Required]
+        [ValidInvoiceType]
         public string Type { get; set; } //New invoice type
 
         /// <summary>

--- a/src/Payments.Core/Models/Invoice/EditInvoiceModel.cs
+++ b/src/Payments.Core/Models/Invoice/EditInvoiceModel.cs
@@ -30,6 +30,8 @@ namespace Payments.Core.Models.Invoice
 
         public IList<RechargeAccount> RechargeAccounts { get; set; } = new List<RechargeAccount>();
 
+        public string Type { get; set; }
+
         public DateTime? DueDate { get; set; }
     }
 

--- a/src/Payments.Mvc/ClientApp/src/components/editItemsTable.tsx
+++ b/src/Payments.Mvc/ClientApp/src/components/editItemsTable.tsx
@@ -22,6 +22,7 @@ interface IProps {
   items: InvoiceItem[];
   discount: InvoiceDiscount;
   taxPercent: number;
+  invoiceType?: string;
   onItemsChange: (value: InvoiceItem[]) => void;
   onDiscountChange: (value: InvoiceDiscount) => void;
   onTaxPercentChange: (value: number) => void;
@@ -73,7 +74,7 @@ export default class EditItemsTable extends React.Component<IProps, IState> {
   }
 
   public render() {
-    const { coupons, discount, taxPercent } = this.props;
+    const { coupons, discount, taxPercent, invoiceType } = this.props;
     const { items } = this.state;
 
     const itemsArray = items.byId.map(id => items.byHash[id]);
@@ -82,6 +83,9 @@ export default class EditItemsTable extends React.Component<IProps, IState> {
     const subtotalCalc = calculateSubTotal(itemsArray);
     const taxCalc = calculateTaxAmount(itemsArray, discount, taxPercent);
     const totalCalc = calculateTotal(itemsArray, discount, taxPercent);
+
+    // Hide discount and tax sections for Recharge invoices
+    const isRechargeInvoice = invoiceType === 'Recharge';
 
     return (
       <div className='table-responsive'>
@@ -124,57 +128,61 @@ export default class EditItemsTable extends React.Component<IProps, IState> {
               <td>${subtotalCalc.toFixed(2)}</td>
               <td />
             </tr>
-            <tr className='align-text-top'>
-              <td />
-              <td />
-              <td>Discount</td>
-              <td>
-                <DiscountInput
-                  coupons={coupons}
-                  discount={discount}
-                  onChange={v => this.onDiscountChange(v)}
-                />
-              </td>
-              <td>
-                {discount.hasDiscount && (
-                  <span>-${discountCalc.toFixed(2)}</span>
-                )}
-              </td>
-              <td>
-                {discount.hasDiscount && (
-                  <button
-                    className='btn-link btn-invoice-delete'
-                    onClick={this.removeDiscount}
-                  >
-                    <i className='fas fa-times' />
-                  </button>
-                )}
-              </td>
-            </tr>
-            <tr>
-              <td />
-              <td />
-              <td>
-                <span>Tax</span>
-                <span className='ms-2'>
-                  <a
-                    href='https://www.taxjar.com/sales-tax-calculator/'
-                    target='_blank'
-                    rel='noopener noreferrer'
-                  >
-                    <i className='fas fa-search' />
-                  </a>
-                </span>
-              </td>
-              <td>
-                <TaxInput
-                  value={taxPercent * 100}
-                  onChange={v => this.onTaxPercentChange(v)}
-                />
-              </td>
-              <td>{!!taxPercent && <span>${taxCalc.toFixed(2)}</span>}</td>
-              <td />
-            </tr>
+            {!isRechargeInvoice && (
+              <tr className='align-text-top'>
+                <td />
+                <td />
+                <td>Discount</td>
+                <td>
+                  <DiscountInput
+                    coupons={coupons}
+                    discount={discount}
+                    onChange={v => this.onDiscountChange(v)}
+                  />
+                </td>
+                <td>
+                  {discount.hasDiscount && (
+                    <span>-${discountCalc.toFixed(2)}</span>
+                  )}
+                </td>
+                <td>
+                  {discount.hasDiscount && (
+                    <button
+                      className='btn-link btn-invoice-delete'
+                      onClick={this.removeDiscount}
+                    >
+                      <i className='fas fa-times' />
+                    </button>
+                  )}
+                </td>
+              </tr>
+            )}
+            {!isRechargeInvoice && (
+              <tr>
+                <td />
+                <td />
+                <td>
+                  <span>Tax</span>
+                  <span className='ms-2'>
+                    <a
+                      href='https://www.taxjar.com/sales-tax-calculator/'
+                      target='_blank'
+                      rel='noopener noreferrer'
+                    >
+                      <i className='fas fa-search' />
+                    </a>
+                  </span>
+                </td>
+                <td>
+                  <TaxInput
+                    value={taxPercent * 100}
+                    onChange={v => this.onTaxPercentChange(v)}
+                  />
+                </td>
+                <td>{!!taxPercent && <span>${taxCalc.toFixed(2)}</span>}</td>
+                <td />
+              </tr>
+            )}
           </tbody>
           <tfoot>
             <tr>

--- a/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
@@ -122,7 +122,8 @@ export default class CreateInvoiceContainer extends React.Component<
       customers,
       memo,
       loading,
-      validate
+      validate,
+      invoiceType
     } = this.state;
 
     return (
@@ -150,6 +151,7 @@ export default class CreateInvoiceContainer extends React.Component<
             coupons={coupons}
             discount={discount}
             taxPercent={taxPercent}
+            invoiceType={invoiceType}
             onItemsChange={v => this.updateProperty('items', v)}
             onDiscountChange={v => this.updateProperty('discount', v)}
             onTaxPercentChange={v => this.updateProperty('taxPercent', v)}

--- a/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
@@ -403,9 +403,27 @@ export default class CreateInvoiceContainer extends React.Component<
       return true;
     }
 
+    // Extract model errors from ModelState
+    let modelErrors: string[] = [];
+    if (result.modelState) {
+      // ModelState is an object where keys are property names and values are arrays of error messages
+      Object.keys(result.modelState).forEach(key => {
+        const errors = result.modelState[key];
+        if (Array.isArray(errors)) {
+          errors.forEach(error => {
+            if (typeof error === 'string') {
+              modelErrors.push(error);
+            } else if (error && error.errorMessage) {
+              modelErrors.push(error.errorMessage);
+            }
+          });
+        }
+      });
+    }
+
     this.setState({
       errorMessage: result.errorMessage,
-      modelErrors: result.modelState.model.errors.map(e => e.errorMessage)
+      modelErrors: modelErrors
     });
     return false;
   };
@@ -449,9 +467,27 @@ export default class CreateInvoiceContainer extends React.Component<
 
       const result = await response.json();
       if (!result.success) {
+        // Extract model errors from ModelState
+        let modelErrors: string[] = [];
+        if (result.modelState) {
+          // ModelState is an object where keys are property names and values are arrays of error messages
+          Object.keys(result.modelState).forEach(key => {
+            const errors = result.modelState[key];
+            if (Array.isArray(errors)) {
+              errors.forEach(error => {
+                if (typeof error === 'string') {
+                  modelErrors.push(error);
+                } else if (error && error.errorMessage) {
+                  modelErrors.push(error.errorMessage);
+                }
+              });
+            }
+          });
+        }
+
         this.setState({
           errorMessage: result.errorMessage,
-          modelErrors: result.modelState.model.errors.map(e => e.errorMessage)
+          modelErrors: modelErrors
         });
         return false;
       }

--- a/src/Payments.Mvc/ClientApp/src/containers/EditInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/EditInvoiceContainer.tsx
@@ -45,6 +45,7 @@ interface IState {
   taxPercent: number;
   memo: string;
   items: InvoiceItem[];
+  type: string;
   loading: boolean;
   errorMessage: string;
   modelErrors: string[];
@@ -94,6 +95,7 @@ export default class EditInvoiceContainer extends React.Component<
       items,
       memo: invoice.memo,
       taxPercent: invoice.taxPercent || 0,
+      type: invoice.type,
 
       errorMessage: '',
       modelErrors: [],
@@ -114,6 +116,7 @@ export default class EditInvoiceContainer extends React.Component<
       items,
       taxPercent,
       memo,
+      type,
       loading,
       validate
     } = this.state;
@@ -127,7 +130,8 @@ export default class EditInvoiceContainer extends React.Component<
         <LoadingModal loading={loading} />
         <div className='card-header card-header-yellow'>
           <h1>
-            Edit Invoice #{id} for {team.name}{' '}
+            Edit {type === 'CC' ? 'Credit Card' : type} Invoice #{id} for{' '}
+            {team.name}{' '}
           </h1>
         </div>
         <div className='card-body invoice-customer'>
@@ -146,6 +150,7 @@ export default class EditInvoiceContainer extends React.Component<
             coupons={coupons}
             discount={discount}
             taxPercent={taxPercent}
+            invoiceType={type}
             onItemsChange={v => this.updateProperty('items', v)}
             onDiscountChange={v => this.updateProperty('discount', v)}
             onTaxPercentChange={v => this.updateProperty('taxPercent', v)}
@@ -297,7 +302,8 @@ export default class EditInvoiceContainer extends React.Component<
       dueDate,
       taxPercent,
       items,
-      memo
+      memo,
+      type
     } = this.state;
 
     const calculatedDiscount = calculateDiscount(items, discount);
@@ -312,7 +318,8 @@ export default class EditInvoiceContainer extends React.Component<
       items,
       manualDiscount: calculatedDiscount,
       memo,
-      taxPercent
+      taxPercent,
+      type
     };
 
     // create save url

--- a/src/Payments.Mvc/ClientApp/src/models/EditInvoice.tsx
+++ b/src/Payments.Mvc/ClientApp/src/models/EditInvoice.tsx
@@ -3,13 +3,14 @@ import { InvoiceCustomer } from './InvoiceCustomer';
 import { InvoiceItem } from './InvoiceItem';
 
 export interface EditInvoice {
-    accountId: number;
-    couponId: number;
-    customer: InvoiceCustomer;
-    memo: string;
-    manualDiscount: number;
-    dueDate?: Date;
-    taxPercent: number;
-    items: InvoiceItem[];
-    attachments: InvoiceAttachment[];
+  accountId: number;
+  couponId: number;
+  customer: InvoiceCustomer;
+  memo: string;
+  manualDiscount: number;
+  dueDate?: Date;
+  taxPercent: number;
+  items: InvoiceItem[];
+  attachments: InvoiceAttachment[];
+  type: string;
 }

--- a/src/Payments.Mvc/Controllers/InvoicesController.cs
+++ b/src/Payments.Mvc/Controllers/InvoicesController.cs
@@ -268,6 +268,7 @@ namespace Payments.Mvc.Controllers
                     Size = a.Size,
                 }).ToList(),
                 RechargeAccounts = invoice.RechargeAccounts?.ToList() ?? new List<RechargeAccount>(),
+                Type = invoice.Type,
             };
 
             // add other relevant data

--- a/src/Payments.Mvc/Services/InvoiceService.cs
+++ b/src/Payments.Mvc/Services/InvoiceService.cs
@@ -68,6 +68,7 @@ namespace Payments.Mvc.Services
                     Memo            = model.Memo,
                     Status          = Invoice.StatusCodes.Draft,
                     Sent            = false,
+                    Type            = model.Type,
                 };
 
                 // add line items

--- a/src/Payments.Mvc/Views/Invoices/Details.cshtml
+++ b/src/Payments.Mvc/Views/Invoices/Details.cshtml
@@ -5,12 +5,15 @@
 @using Payments.Mvc.Models.CyberSource
 @using Payments.Mvc.Identity
 @using Payments.Mvc.Models.Roles
+@using static Payments.Core.Domain.Invoice
 @model Invoice
 @inject IHttpContextAccessor _httpContextAccessor
 @inject ApplicationUserManager _applicationUserManager
 
 @{
-    ViewBag.Title = $"Invoice #{Model.GetFormattedId()}";
+    var InvoiceType = Model.Type == InvoiceTypes.CreditCard ? "Credit Card" : "Recharge";
+
+    ViewBag.Title = $"{InvoiceType} Invoice #{Model.GetFormattedId()}";
     Layout = "_Layout";
 
     var teamSlug = _httpContextAccessor.HttpContext.GetRouteData().Values["team"] as string;

--- a/tests/Payments.Tests/DatabaseTests/CreateInvoiceModelValidationTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/CreateInvoiceModelValidationTests.cs
@@ -1,0 +1,118 @@
+using Payments.Core.Models.Invoice;
+using Payments.Core.Domain;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using Xunit;
+
+namespace Payments.Tests.DatabaseTests
+{
+    [Trait("Category", "DatabaseTests")]
+    public class CreateInvoiceModelValidationTests
+    {
+        [Fact]
+        public void CreateInvoiceModel_Type_ValidValues_ShouldPass()
+        {
+            // Arrange
+            var model = new CreateInvoiceModel
+            {
+                Type = "CC"
+            };
+
+            // Act
+            var validationResults = ValidateModel(model);
+
+            // Assert
+            Assert.DoesNotContain(validationResults, v => v.MemberNames.Contains("Type"));
+        }
+
+        [Fact]
+        public void CreateInvoiceModel_Type_ValidRechargeValue_ShouldPass()
+        {
+            // Arrange
+            var model = new CreateInvoiceModel
+            {
+                Type = "Recharge"
+            };
+
+            // Act
+            var validationResults = ValidateModel(model);
+
+            // Assert
+            Assert.DoesNotContain(validationResults, v => v.MemberNames.Contains("Type"));
+        }
+
+        [Fact]
+        public void CreateInvoiceModel_Type_UsesInvoiceTypeConstants_ShouldPass()
+        {
+            // Arrange & Act - Test using the actual constants from Invoice.InvoiceTypes
+            var ccModel = new CreateInvoiceModel { Type = Invoice.InvoiceTypes.CreditCard };
+            var rechargeModel = new CreateInvoiceModel { Type = Invoice.InvoiceTypes.Recharge };
+
+            var ccResults = ValidateModel(ccModel);
+            var rechargeResults = ValidateModel(rechargeModel);
+
+            // Assert
+            Assert.DoesNotContain(ccResults, v => v.MemberNames.Contains("Type"));
+            Assert.DoesNotContain(rechargeResults, v => v.MemberNames.Contains("Type"));
+        }
+
+        [Fact]
+        public void CreateInvoiceModel_Type_InvalidValue_ShouldFail()
+        {
+            // Arrange
+            var model = new CreateInvoiceModel
+            {
+                Type = "InvalidType"
+            };
+
+            // Act
+            var validationResults = ValidateModel(model);
+
+            // Assert
+            Assert.Contains(validationResults, v =>
+                v.MemberNames.Contains("Type") &&
+                v.ErrorMessage == "The Type field must be either 'CC' or 'Recharge'.");
+        }
+
+        [Fact]
+        public void CreateInvoiceModel_Type_NullValue_ShouldFail()
+        {
+            // Arrange
+            var model = new CreateInvoiceModel
+            {
+                Type = null
+            };
+
+            // Act
+            var validationResults = ValidateModel(model);
+
+            // Assert
+            Assert.Contains(validationResults, v => v.MemberNames.Contains("Type"));
+        }
+
+        [Fact]
+        public void CreateInvoiceModel_Type_EmptyValue_ShouldFail()
+        {
+            // Arrange
+            var model = new CreateInvoiceModel
+            {
+                Type = ""
+            };
+
+            // Act
+            var validationResults = ValidateModel(model);
+
+            // Assert
+            Assert.Contains(validationResults, v => v.MemberNames.Contains("Type"));
+        }
+
+        private static IList<ValidationResult> ValidateModel(object model)
+        {
+            var validationResults = new List<ValidationResult>();
+            var ctx = new ValidationContext(model, null, null);
+            Validator.TryValidateObject(model, ctx, validationResults, true);
+            return validationResults;
+        }
+    }
+}

--- a/tests/Payments.Tests/DatabaseTests/RechargeAccountTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/RechargeAccountTests.cs
@@ -19,7 +19,23 @@ namespace Payments.Tests.DatabaseTests
                 "[System.ComponentModel.DataAnnotations.RangeAttribute((Double)0.01, (Double)1000000)]",
                 "[System.ComponentModel.DataAnnotations.RequiredAttribute()]",
             }));
+            expectedFields.Add(new NameAndType("ApprovedByKerb", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)20)]",
+            }));
+            expectedFields.Add(new NameAndType("ApprovedByName", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)128)]",
+            }));
             expectedFields.Add(new NameAndType("Direction", "Payments.Core.Domain.RechargeAccount+CreditDebit", new List<string>()));
+            expectedFields.Add(new NameAndType("EnteredByKerb", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)20)]",
+            }));
+            expectedFields.Add(new NameAndType("EnteredByName", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)128)]",
+            }));
             expectedFields.Add(new NameAndType("FinancialSegmentString", "System.String", new List<string>
             {
                 "[System.ComponentModel.DataAnnotations.RequiredAttribute()]",
@@ -33,6 +49,10 @@ namespace Payments.Tests.DatabaseTests
             expectedFields.Add(new NameAndType("InvoiceId", "System.Int32", new List<string>
             {
                 "[System.ComponentModel.DataAnnotations.RequiredAttribute()]",
+            }));
+            expectedFields.Add(new NameAndType("Notes", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)400)]",
             }));
             expectedFields.Add(new NameAndType("Percentage", "System.Decimal", new List<string>()));
             #endregion Arrange


### PR DESCRIPTION
Enforces validation for the invoice type field, ensuring it adheres to predefined allowed values (Credit Card or Recharge).

This change introduces a custom validation attribute, `ValidInvoiceTypeAttribute`, to check if the provided invoice type is valid. This attribute is then applied to the `Type` property in the `CreateInvoiceModel`.

Adds tests to ensure the type validation works correctly.