### PR TITLE
Adds checkApprover parameter to recharge validation

### DIFF
--- a/src/Payments.Core/Services/AggieEnterpriseService.cs
+++ b/src/Payments.Core/Services/AggieEnterpriseService.cs
@@ -410,14 +410,14 @@ namespace Payments.Core.Services
                 }
             }
 
-#if DEBUG
-            rtValue.Approvers.Add(new Approver
-            {
-                FirstName = "Jason",
-                LastName = "Sylvestre",
-                Email = "jsylvestre@ucdavis.edu",
-            });
-#endif
+//#if DEBUG
+//            rtValue.Approvers.Add(new Approver
+//            {
+//                FirstName = "Jason",
+//                LastName = "Sylvestre",
+//                Email = "jsylvestre@ucdavis.edu",
+//            });
+//#endif
 
             return rtValue;
         }

--- a/src/Payments.Mvc/ClientApp/src/components/rechargeAccountsControl.tsx
+++ b/src/Payments.Mvc/ClientApp/src/components/rechargeAccountsControl.tsx
@@ -353,10 +353,12 @@ export default class RechargeAccountsControl extends React.Component<
 
     try {
       const directionValue = direction === 'Credit' ? 0 : 1;
+      // Add checkApprover param when fromApprove is true and direction is Debit
+      const checkApprover = this.props.fromApprove && direction === 'Debit';
       const response = await fetch(
         `/api/recharge/validate?chartString=${encodeURIComponent(
           chartString
-        )}&direction=${directionValue}`,
+        )}&direction=${directionValue}&checkApprover=${checkApprover}`,
         {
           method: 'GET',
           headers: {


### PR DESCRIPTION
Adds a checkApprover parameter to the recharge validation API call when the user is approving a recharge and the direction is Debit. This will be used to check if the user is an approver for the account.

Removes test approver from AggieEnterpriseService.