### PR TITLE
Removes RequestVerificationToken header

### DIFF
--- a/src/Payments.Mvc/ClientApp/src/components/fileUpload.tsx
+++ b/src/Payments.Mvc/ClientApp/src/components/fileUpload.tsx
@@ -175,9 +175,9 @@ export default class FileUpload extends React.Component<IProps, IState> {
       axios(`${slug}/files/uploadfile`, {
         cancelToken: newAttachment.cancelToken.token,
         data,
-        headers: {
-          RequestVerificationToken: antiForgeryToken
-        },
+        //headers: {
+        //  RequestVerificationToken: antiForgeryToken
+        //},
         method: 'post',
         onUploadProgress: progressEvent =>
           this.onUploadProgress(progressEvent, newAttachment.identifier)


### PR DESCRIPTION
Removes the RequestVerificationToken header from the file upload request.

Endpoint ignores it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file upload request handling to improve compatibility and reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->