### PR TITLE
Adds credentials to upload request

### DIFF
--- a/src/Payments.Mvc/ClientApp/src/components/fileUpload.tsx
+++ b/src/Payments.Mvc/ClientApp/src/components/fileUpload.tsx
@@ -179,6 +179,7 @@ export default class FileUpload extends React.Component<IProps, IState> {
           RequestVerificationToken: antiForgeryToken
         },
         method: 'post',
+        withCredentials: true,
         onUploadProgress: progressEvent =>
           this.onUploadProgress(progressEvent, newAttachment.identifier)
       })


### PR DESCRIPTION
Ensures that the file upload request includes credentials. This resolves an issue where authentication information was not being sent with the request, preventing
successful uploads for authenticated users.

Relates to JCS/FixUpload20251120

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * File upload now properly supports authenticated requests with session credentials.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->