### PR TITLE
Hides "Set back to paid" option for Recharges

### DIFF
--- a/src/Payments.Mvc/Views/Invoices/Details.cshtml
+++ b/src/Payments.Mvc/Views/Invoices/Details.cshtml
@@ -138,7 +138,7 @@
                 Mark as paid
             </button>
         }
-        @if (Model.Status == Invoice.StatusCodes.Processing && User.IsInRole(ApplicationRoleCodes.Admin))
+        @if (Model.Type != InvoiceTypes.Recharge && Model.Status == Invoice.StatusCodes.Processing && User.IsInRole(ApplicationRoleCodes.Admin))
         {
             var modalTarget = User.IsInRole(ApplicationRoleCodes.Admin)
                 ? "#setBackPaidModal"


### PR DESCRIPTION
Ensures that the "Set back to paid" option is not displayed for Recharge invoices, as this action is not applicable to them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the "Set Back to Paid" admin action was available for Recharge invoices. This option is now restricted to standard invoice types only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->