### PR TITLE
Clears tax/coupon on Recharge invoice type change

### DIFF
--- a/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
@@ -257,12 +257,7 @@ export default class CreateInvoiceContainer extends React.Component<
           <div className='invoice-type-toggle-container'>
             <div
               className='invoice-type-toggle'
-              onClick={() =>
-                this.updateProperty(
-                  'invoiceType',
-                  invoiceType === 'CC' ? 'Recharge' : 'CC'
-                )
-              }
+              onClick={this.handleInvoiceTypeChange}
             >
               <div
                 className={`invoice-type-toggle-option ${
@@ -372,19 +367,26 @@ export default class CreateInvoiceContainer extends React.Component<
   }
 
   private updateProperty = (name: any, value: any) => {
-    // When switching to Recharge invoice type, clear tax and coupon
-    if (name === 'invoiceType' && value === 'Recharge') {
+    this.setState(({
+      [name]: value
+    } as unknown) as IState);
+  };
+
+  private handleInvoiceTypeChange = () => {
+    const { invoiceType } = this.state;
+    const newInvoiceType = invoiceType === 'CC' ? 'Recharge' : 'CC';
+
+    // When switching to Recharge, clear tax and coupon
+    if (newInvoiceType === 'Recharge') {
       this.setState({
-        invoiceType: value,
+        invoiceType: newInvoiceType,
         taxPercent: 0,
         discount: {
           hasDiscount: false
         }
-      } as IState);
+      });
     } else {
-      this.setState(({
-        [name]: value
-      } as unknown) as IState);
+      this.setState({ invoiceType: newInvoiceType });
     }
   };
 


### PR DESCRIPTION
When the invoice type is changed to "Recharge," it resets the tax percentage and removes any existing discount to ensure data consistency.

Relates to JCS/RechargeTaxCouponFix

close #445 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switching invoice type to "Recharge" now clears tax percentage and removes any applied discount to prevent incorrect charges.
* **Refactor**
  * Improved invoice-type toggle handling for more predictable state updates and clearer behavior when switching types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->