### PR TITLE
Adds email warning for non-UCDavis emails

### DIFF
--- a/src/Payments.Mvc/ClientApp/src/components/emailWarning.tsx
+++ b/src/Payments.Mvc/ClientApp/src/components/emailWarning.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+
+import { InvoiceCustomer } from '../models/InvoiceCustomer';
+
+interface IProps {
+  invoiceType: string;
+  customers?: InvoiceCustomer[];
+  customer?: InvoiceCustomer;
+}
+
+export default class EmailWarning extends React.Component<IProps> {
+  public render() {
+    const { invoiceType, customers, customer } = this.props;
+
+    // Only show warning for Recharge invoices
+    if (invoiceType !== 'Recharge') {
+      return null;
+    }
+
+    let hasNonUCDavisEmail = false;
+
+    // Check for multiple customers (create invoice)
+    if (customers) {
+      hasNonUCDavisEmail = customers.some(
+        c => c.email && !c.email.toLowerCase().endsWith('ucdavis.edu')
+      );
+    }
+    // Check for single customer (edit invoice)
+    else if (customer) {
+      hasNonUCDavisEmail =
+        !!customer.email &&
+        !customer.email.toLowerCase().endsWith('ucdavis.edu');
+    }
+
+    if (!hasNonUCDavisEmail) {
+      return null;
+    }
+
+    return (
+      <div className='alert alert-warning mt-2' role='alert'>
+        <i className='fas fa-exclamation-triangle me-2'></i>
+        <strong>Warning:</strong> Recharge invoices should typically use a
+        ucdavis.edu email address.
+      </div>
+    );
+  }
+}

--- a/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/CreateInvoiceContainer.tsx
@@ -19,6 +19,7 @@ import Alert from '../components/alert';
 import AttachmentsControl from '../components/attachmentsControl';
 import DueDateControl from '../components/dueDateControl';
 import EditItemsTable from '../components/editItemsTable';
+import EmailWarning from '../components/emailWarning';
 import InvoiceForm from '../components/invoiceForm';
 import LoadingModal from '../components/loadingModal';
 import MemoInput from '../components/memoInput';
@@ -149,6 +150,7 @@ export default class CreateInvoiceContainer extends React.Component<
             onChange={c => this.updateProperty('customers', c)}
           />
           <div className='invalid-feedback'>Customer required.</div>
+          <EmailWarning invoiceType={invoiceType} customers={customers} />
         </div>
         <div className='card-body invoice-items'>
           <h2>Invoice Items</h2>

--- a/src/Payments.Mvc/ClientApp/src/containers/EditInvoiceContainer.tsx
+++ b/src/Payments.Mvc/ClientApp/src/containers/EditInvoiceContainer.tsx
@@ -21,6 +21,7 @@ import AttachmentsControl from '../components/attachmentsControl';
 import CustomerControl from '../components/customerControl';
 import DueDateControl from '../components/dueDateControl';
 import EditItemsTable from '../components/editItemsTable';
+import EmailWarning from '../components/emailWarning';
 import InvoiceForm from '../components/invoiceForm';
 import LoadingModal from '../components/loadingModal';
 import MemoInput from '../components/memoInput';
@@ -148,6 +149,7 @@ export default class EditInvoiceContainer extends React.Component<
               this.updateProperty('customer', c);
             }}
           />
+          <EmailWarning invoiceType={type} customer={customer} />
         </div>
         <div className='card-body invoice-items'>
           <h3>Invoice Items</h3>


### PR DESCRIPTION
Displays a warning message on invoice creation and edit pages if a non-ucdavis.edu email address is used for Recharge invoices. This informs users that Recharge invoices typically require a ucdavis.edu email.

Relates to JCS/20260115

<img width="2076" height="817" alt="image" src="https://github.com/user-attachments/assets/490b0553-6220-4adc-944d-85b97a012f51" />

<img width="2036" height="1125" alt="image" src="https://github.com/user-attachments/assets/f96085a8-227d-46a4-8715-00ff10caebba" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added email validation warning for Recharge invoices. When creating or editing Recharge invoices, a warning alert now appears if non-institutional email addresses are detected, encouraging users to use ucdavis.edu email addresses instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->