### PR TITLE
Allows source maps from CDN

### DIFF
--- a/src/Payments.Mvc/Startup.cs
+++ b/src/Payments.Mvc/Startup.cs
@@ -302,6 +302,7 @@ namespace Payments.Mvc
 
 
                 c.AllowStyles
+                    .FromSelf()
                     .From("https://stackpath.bootstrapcdn.com")
                     .From("https://use.fontawesome.com")
                     .From("https://cdn.datatables.net")


### PR DESCRIPTION
Adds jsdelivr to the Content Security Policy (CSP) to allow loading of source maps from the CDN.

Relates to JCS/Suggestions20260120