### PR TITLE
Add covering index to PaymentEvent for InvoiceId

### DIFF
--- a/src/Payments.Core/Data/ApplicationDbContext.cs
+++ b/src/Payments.Core/Data/ApplicationDbContext.cs
@@ -59,6 +59,7 @@ namespace Payments.Core.Data
             Invoice.OnModelCreating(builder);
             LogMessage.OnModelCreating(builder);
             MoneyMovementJobRecord.OnModelCreating(builder);
+            PaymentEvent.OnModelCreating(builder);
             TaxReportJobRecord.OnModelCreating(builder);
             Team.OnModelCreating(builder);
             RechargeAccount.OnModelCreating(builder);

--- a/src/Payments.Core/Domain/PaymentEvent.cs
+++ b/src/Payments.Core/Domain/PaymentEvent.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 
 namespace Payments.Core.Domain
@@ -86,5 +87,33 @@ namespace Payments.Core.Domain
         public DateTime OccuredAt { get; set; }
 
         public Invoice Invoice { get; set; }
+
+        protected internal static void OnModelCreating(ModelBuilder builder)
+        {
+            builder.Entity<PaymentEvent>()
+                .HasIndex("InvoiceId")
+                .HasDatabaseName("nci_msft_1_PaymentEvents_99E8BA0523EFE2FDCB09326BF709CC4D")
+                .IncludeProperties(
+                    nameof(Amount),
+                    nameof(BillingCity),
+                    nameof(BillingCompany),
+                    nameof(BillingCountry),
+                    nameof(BillingEmail),
+                    nameof(BillingFirstName),
+                    nameof(BillingLastName),
+                    nameof(BillingPhone),
+                    nameof(BillingPostalCode),
+                    nameof(BillingState),
+                    nameof(BillingStreet1),
+                    nameof(BillingStreet2),
+                    nameof(CardExpiry),
+                    nameof(CardNumber),
+                    nameof(CardType),
+                    nameof(Decision),
+                    nameof(OccuredAt),
+                    nameof(Processor),
+                    nameof(ProcessorId),
+                    nameof(ReturnedResults));
+        }
     }
 }

--- a/src/Payments.Core/Migrations/20260413200623_PaymentEventInvoiceCoveringIndex.Designer.cs
+++ b/src/Payments.Core/Migrations/20260413200623_PaymentEventInvoiceCoveringIndex.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Payments.Core.Data;
 
@@ -11,9 +12,10 @@ using Payments.Core.Data;
 namespace Payments.Core.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413200623_PaymentEventInvoiceCoveringIndex")]
+    partial class PaymentEventInvoiceCoveringIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Payments.Core/Migrations/20260413200623_PaymentEventInvoiceCoveringIndex.cs
+++ b/src/Payments.Core/Migrations/20260413200623_PaymentEventInvoiceCoveringIndex.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Payments.Core.Migrations
+{
+    public partial class PaymentEventInvoiceCoveringIndex : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'IX_PaymentEvents_InvoiceId'
+      AND object_id = OBJECT_ID(N'[dbo].[PaymentEvents]')
+)
+DROP INDEX [IX_PaymentEvents_InvoiceId] ON [dbo].[PaymentEvents];
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'nci_msft_1_PaymentEvents_99E8BA0523EFE2FDCB09326BF709CC4D'
+      AND object_id = OBJECT_ID(N'[dbo].[PaymentEvents]')
+)
+CREATE NONCLUSTERED INDEX [nci_msft_1_PaymentEvents_99E8BA0523EFE2FDCB09326BF709CC4D]
+ON [dbo].[PaymentEvents] ([InvoiceId])
+INCLUDE ([Amount], [BillingCity], [BillingCompany], [BillingCountry], [BillingEmail], [BillingFirstName], [BillingLastName], [BillingPhone], [BillingPostalCode], [BillingState], [BillingStreet1], [BillingStreet2], [CardExpiry], [CardNumber], [CardType], [Decision], [OccuredAt], [Processor], [ProcessorId], [ReturnedResults]);
+");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+IF EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'nci_msft_1_PaymentEvents_99E8BA0523EFE2FDCB09326BF709CC4D'
+      AND object_id = OBJECT_ID(N'[dbo].[PaymentEvents]')
+)
+DROP INDEX [nci_msft_1_PaymentEvents_99E8BA0523EFE2FDCB09326BF709CC4D] ON [dbo].[PaymentEvents];
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.indexes
+    WHERE name = N'IX_PaymentEvents_InvoiceId'
+      AND object_id = OBJECT_ID(N'[dbo].[PaymentEvents]')
+)
+CREATE INDEX [IX_PaymentEvents_InvoiceId] ON [dbo].[PaymentEvents] ([InvoiceId]);
+");
+        }
+    }
+}


### PR DESCRIPTION
Improves query performance for payment event lookups by creating a non-clustered index on InvoiceId that includes frequently accessed properties, reducing the need for table lookups.

Applied the script created in azure as a recommendation :
CREATE NONCLUSTERED INDEX [nci_msft_1_PaymentEvents_99E8BA0523EFE2FDCB09326BF709CC4D] ON [dbo].[PaymentEvents] ([InvoiceId]) INCLUDE ([Amount], [BillingCity], [BillingCompany], [BillingCountry], [BillingEmail], [BillingFirstName], [BillingLastName], [BillingPhone], [BillingPostalCode], [BillingState], [BillingStreet1], [BillingStreet2], [CardExpiry], [CardNumber], [CardType], [Decision], [OccuredAt], [Processor], [ProcessorId], [ReturnedResults]) WITH (ONLINE = ON)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database performance through enhanced indexing of payment transaction records to improve query efficiency and overall application responsiveness when processing payment-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->