### PR TITLE
Expose RechargeAccount direction as string property

### DIFF
--- a/src/Payments.Core/Domain/RechargeAccount.cs
+++ b/src/Payments.Core/Domain/RechargeAccount.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using System;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Payments.Core.Domain
 {
@@ -17,6 +18,9 @@ namespace Payments.Core.Domain
         public Invoice Invoice { get; set; }
 
         public CreditDebit Direction { get; set; } = CreditDebit.Credit;
+
+        [NotMapped]
+        public string DirectionType => Direction.ToString();
 
         [Required]
         [StringLength(128)]

--- a/src/Payments.Mvc/Startup.cs
+++ b/src/Payments.Mvc/Startup.cs
@@ -152,7 +152,7 @@ namespace Payments.Mvc
                 Configuration.GetValue<string>("JsReport:ServiceUrl"),
                 Configuration.GetValue<string>("JsReport:Username"),
                 Configuration.GetValue<string>("JsReport:Password")));
-
+           
             // add swagger
             services.AddSwaggerGen(c =>
             {
@@ -163,8 +163,8 @@ namespace Payments.Mvc
                     Description = "Accept and process credit card payments for CA&ES",
                     Contact = new OpenApiContact()
                     {
-                        Name = "CAES Application Requests",
-                        Email = "apprequests@caes.ucdavis.edu"
+                        Name = "CAES Help Requests",
+                        Url = new Uri("https://caeshelp.ucdavis.edu/?appname=Payments")
                     },
                     License = new OpenApiLicense()
                     {

--- a/src/Payments.Mvc/Swagger/SecurityRequirementsOperationFilter.cs
+++ b/src/Payments.Mvc/Swagger/SecurityRequirementsOperationFilter.cs
@@ -52,18 +52,19 @@ namespace Payments.Mvc.Swagger
                 operation.Parameters = new List<OpenApiParameter>();
             }
 
-            operation.Parameters.Add(new OpenApiParameter
-            {
-                Name = "X-Auth-Token", //ApiKeyMiddleware.HeaderKey,
-                In = ParameterLocation.Header,
-                Description = "access token",
-                Required = true,
-                Schema = new OpenApiSchema
-                {
-                    Type = "string",
-                    Default = new OpenApiString("ApiKey"),
-                }
-            });
+            //Having this parameter causes confusion in swagger UI as the main authorization must be used
+            //operation.Parameters.Add(new OpenApiParameter
+            //{
+            //    Name = "X-Auth-Token", //ApiKeyMiddleware.HeaderKey,
+            //    In = ParameterLocation.Header,
+            //    Description = "access token",
+            //    Required = true,
+            //    Schema = new OpenApiSchema
+            //    {
+            //        Type = "string",
+            //        Default = new OpenApiString("ApiKey"),
+            //    }
+            //});
         }
     }
 }

--- a/tests/Payments.Tests/DatabaseTests/RechargeAccountTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/RechargeAccountTests.cs
@@ -28,6 +28,10 @@ namespace Payments.Tests.DatabaseTests
                 "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)128)]",
             }));
             expectedFields.Add(new NameAndType("Direction", "Payments.Core.Domain.RechargeAccount+CreditDebit", new List<string>()));
+            expectedFields.Add(new NameAndType("DirectionType", "System.String", new List<string>
+            {
+                "[System.ComponentModel.DataAnnotations.Schema.NotMappedAttribute()]",
+            }));
             expectedFields.Add(new NameAndType("EnteredByKerb", "System.String", new List<string>
             {
                 "[System.ComponentModel.DataAnnotations.StringLengthAttribute((Int32)20)]",
@@ -62,6 +66,19 @@ namespace Payments.Tests.DatabaseTests
 
             AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(RechargeAccount));
 
+        }
+
+        [Theory]
+        [InlineData(RechargeAccount.CreditDebit.Credit, "Credit")]
+        [InlineData(RechargeAccount.CreditDebit.Debit, "Debit")]
+        public void DirectionTypeReturnsDirectionName(RechargeAccount.CreditDebit direction, string expected)
+        {
+            var rechargeAccount = new RechargeAccount
+            {
+                Direction = direction
+            };
+
+            Assert.Equal(expected, rechargeAccount.DirectionType);
         }
     }
 }


### PR DESCRIPTION
So API calls to get details are clear

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a human-readable direction label for recharge accounts (Credit/Debit).

* **Bug Fixes**
  * Updated validation to stay consistent with the new non-persisted direction label.

* **Tests**
  * Extended database tests to verify the direction label output for both Credit and Debit values.

* **Documentation / API Updates**
  * Refreshed Swagger contact details and removed the declared `X-Auth-Token` header from Swagger operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->