### PR TITLE
Separate customer name into first and last name for CyberSource billing

### DIFF
--- a/src/Payments.Core/Domain/Invoice.cs
+++ b/src/Payments.Core/Domain/Invoice.cs
@@ -256,6 +256,8 @@ namespace Payments.Core.Domain
 
         public Dictionary<string, string> GetPaymentDictionary()
         {
+            var billingName = CustomerName.ParseFirstAndLastName();
+
             var dictionary = new Dictionary<string, string>
             {
                 {"transaction_type"       , "sale"},
@@ -267,7 +269,8 @@ namespace Payments.Core.Domain
                 {"unsigned_field_names"   , string.Empty},
                 {"locale"                 , "en"},
                 {"bill_to_email"          , CustomerEmail},
-                {"bill_to_forename"       , CustomerName.SafeTruncate(60)},
+                {"bill_to_forename"       , billingName.FirstName.SafeTruncate(60)},
+                {"bill_to_surname"        , billingName.LastName.SafeTruncate(60)},
                 {"bill_to_company_name"   , CustomerCompany.SafeRegexRemove().SafeTruncate(40)},
                 {"bill_to_address_country", "US"},
                 {"bill_to_address_state"  , "CA"}

--- a/src/Payments.Core/Extensions/StringExtensions.cs
+++ b/src/Payments.Core/Extensions/StringExtensions.cs
@@ -49,6 +49,11 @@ namespace Payments.Core.Extensions
             
         }
 
+        /// <summary>
+        /// Splits a full name into first and last name parts using only spaces as delimiters.
+        /// For one-word names, the word is treated as the last name; for names with more than two words, the final word is the last name and the rest is the first name.
+        /// Null input returns null parts, and empty or space-only input returns empty parts.
+        /// </summary>
         public static (string FirstName, string LastName) ParseFirstAndLastName(this string value)
         {
             if (value == null)

--- a/src/Payments.Core/Extensions/StringExtensions.cs
+++ b/src/Payments.Core/Extensions/StringExtensions.cs
@@ -46,8 +46,34 @@ namespace Payments.Core.Extensions
             {
                 return value;
             }
-
             
+        }
+
+        public static (string FirstName, string LastName) ParseFirstAndLastName(this string value)
+        {
+            if (value == null)
+            {
+                return (null, null);
+            }
+
+            if (value == string.Empty)
+            {
+                return (string.Empty, string.Empty);
+            }
+
+            var names = value.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            if (names.Length == 0)
+            {
+                return (string.Empty, string.Empty);
+            }
+
+            if (names.Length == 1)
+            {
+                return (string.Empty, names[0]);
+            }
+
+            return (string.Join(" ", names, 0, names.Length - 1), names[names.Length - 1]);
         }
     }
 }

--- a/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
@@ -306,7 +306,7 @@ namespace Payments.Tests.DatabaseTests
 
             // Assert		
             result.ShouldBeOfType<Dictionary<string, string>>();
-            result.Count.ShouldBe(14 + (2 * invoice.Items.Count));
+            result.Count.ShouldBe(15 + (2 * invoice.Items.Count));
 
             result["transaction_type"].ShouldBe("sale");
             result["reference_number"].ShouldBe(invoice.Id.ToString());
@@ -317,7 +317,8 @@ namespace Payments.Tests.DatabaseTests
             result["unsigned_field_names"].ShouldBe("");
             result["locale"].ShouldBe("en");
             result["bill_to_email"].ShouldBe(invoice.CustomerEmail);
-            result["bill_to_forename"].ShouldBe(invoice.CustomerName);
+            result["bill_to_forename"].ShouldBe(string.Empty);
+            result["bill_to_surname"].ShouldBe(invoice.CustomerName);
             result["bill_to_address_country"].ShouldBe("US");
             result["bill_to_address_state"].ShouldBe("CA");
             result["line_item_count"].ShouldBe(value.ToString());
@@ -349,7 +350,7 @@ namespace Payments.Tests.DatabaseTests
 
             // Assert		
             result.ShouldBeOfType<Dictionary<string, string>>();
-            result.Count.ShouldBe(14 + (2 * invoice.Items.Count));
+            result.Count.ShouldBe(15 + (2 * invoice.Items.Count));
 
             result["transaction_type"].ShouldBe("sale");
             result["reference_number"].ShouldBe(invoice.Id.ToString());
@@ -360,7 +361,8 @@ namespace Payments.Tests.DatabaseTests
             result["unsigned_field_names"].ShouldBe("");
             result["locale"].ShouldBe("en");
             result["bill_to_email"].ShouldBe(invoice.CustomerEmail);
-            result["bill_to_forename"].ShouldBe(invoice.CustomerName);
+            result["bill_to_forename"].ShouldBe(string.Empty);
+            result["bill_to_surname"].ShouldBe(invoice.CustomerName);
             result["bill_to_address_country"].ShouldBe("US");
             result["bill_to_address_state"].ShouldBe("CA");
             result["line_item_count"].ShouldBe(value.ToString());
@@ -395,7 +397,7 @@ namespace Payments.Tests.DatabaseTests
 
             // Assert		
             result.ShouldBeOfType<Dictionary<string, string>>();
-            result.Count.ShouldBe(14 + (2 * invoice.Items.Count));
+            result.Count.ShouldBe(15 + (2 * invoice.Items.Count));
 
             result["transaction_type"].ShouldBe("sale");
             result["reference_number"].ShouldBe(invoice.Id.ToString());
@@ -406,7 +408,8 @@ namespace Payments.Tests.DatabaseTests
             result["unsigned_field_names"].ShouldBe("");
             result["locale"].ShouldBe("en");
             result["bill_to_email"].ShouldBe(invoice.CustomerEmail);
-            result["bill_to_forename"].ShouldBe(invoice.CustomerName);
+            result["bill_to_forename"].ShouldBe(string.Empty);
+            result["bill_to_surname"].ShouldBe(invoice.CustomerName);
             result["bill_to_address_country"].ShouldBe("US");
             result["bill_to_address_state"].ShouldBe("CA");
             result["line_item_count"].ShouldBe("1");
@@ -429,27 +432,28 @@ namespace Payments.Tests.DatabaseTests
         }
 
         [Theory]
-        [InlineData("123456789 123456789 123456789 123456789 123456789 123456789X", "123456789 123456789 123456789 123456789 123456789 123456789X")]
-        [InlineData("123456789 123456789 123456789 123456789 123456789 123456789X1", "123456789 123456789 123456789 123456789 123456789 123456789X")]
-        [InlineData("123", "123")]
-        [InlineData("", "")]
-        [InlineData(" ", " ")]
-        [InlineData(null, null)]
-        public void TestCyberSourceTruncationOfDictionaryFieldCustomerName(string value, string expectedValue)
+        [InlineData("Jane Doe", "Jane", "Doe")]
+        [InlineData("Jane", "", "Jane")]
+        [InlineData("Mary Ann Smith", "Mary Ann", "Smith")]
+        [InlineData("Mary  Ann  Smith", "Mary Ann", "Smith")]
+        [InlineData("Mary\tSmith", "", "Mary\tSmith")]
+        [InlineData("", "", "")]
+        [InlineData(" ", "", "")]
+        [InlineData(null, null, null)]
+        public void TestCyberSourceParsesCustomerNameIntoDictionaryFields(string value, string expectedFirstName, string expectedLastName)
         {
             // Arrange
             var invoice = CreateValidEntities.Invoice(1, 1);
             invoice.CustomerName = value;
             invoice.UpdateCalculatedValues();
             invoice.CustomerEmail.ShouldNotBeNull();
-            
 
             // Act
             var result = invoice.GetPaymentDictionary();
 
             // Assert		
             result.ShouldBeOfType<Dictionary<string, string>>();
-            result.Count.ShouldBe(14 + (2 * invoice.Items.Count));
+            result.Count.ShouldBe(15 + (2 * invoice.Items.Count));
 
             result["transaction_type"].ShouldBe("sale");
             result["reference_number"].ShouldBe(invoice.Id.ToString());
@@ -460,18 +464,11 @@ namespace Payments.Tests.DatabaseTests
             result["unsigned_field_names"].ShouldBe("");
             result["locale"].ShouldBe("en");
             result["bill_to_email"].ShouldBe(invoice.CustomerEmail);
+            result["bill_to_forename"].ShouldBe(expectedFirstName);
+            result["bill_to_surname"].ShouldBe(expectedLastName);
             result["bill_to_address_country"].ShouldBe("US");
             result["bill_to_address_state"].ShouldBe("CA");
             result["line_item_count"].ShouldBe("1");
-            if (expectedValue == null)
-            {
-                result["bill_to_forename"].ShouldBeNull();
-            }
-            else
-            {
-                result["bill_to_forename"].Length.ShouldBeLessThanOrEqualTo(60);
-                result["bill_to_forename"].ShouldBe(expectedValue);
-            }
 
             for (int i = 0; i < 1; i++)
             {
@@ -479,6 +476,25 @@ namespace Payments.Tests.DatabaseTests
                 //result[$"item_{i}_quantity"].ShouldBe(invoice.Items[i].Quantity.ToString()); //This is gone
                 result[$"item_{i}_unit_price"].ShouldBe((invoice.Items[i].Amount * invoice.Items[i].Quantity).ToString("F2"));
             }
+        }
+
+        [Theory]
+        [InlineData("123456789012345678901234567890123456789012345678901234567890X", "123456789012345678901234567890123456789012345678901234567890")]
+        public void TestCyberSourceTruncationOfDictionaryFieldCustomerLastName(string value, string expectedValue)
+        {
+            // Arrange
+            var invoice = CreateValidEntities.Invoice(1, 1);
+            invoice.CustomerName = value;
+            invoice.UpdateCalculatedValues();
+            invoice.CustomerEmail.ShouldNotBeNull();
+
+            // Act
+            var result = invoice.GetPaymentDictionary();
+
+            // Assert		
+            result["bill_to_forename"].ShouldBe(string.Empty);
+            result["bill_to_surname"].Length.ShouldBeLessThanOrEqualTo(60);
+            result["bill_to_surname"].ShouldBe(expectedValue);
         }
 
         [Fact]


### PR DESCRIPTION
<img width="3555" height="763" alt="image" src="https://github.com/user-attachments/assets/f4d36973-4e48-4af7-8de1-7a17f4545be1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Customer names are now split into first and last name fields when building payment details, improving how billing information is sent.

* **Bug Fixes**
  * Updated billing name handling so last names are populated correctly and long name values are safely truncated.
  * Adjusted payment-related tests to match the updated name parsing and field counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->