### PR TITLE
Add email notifications for financial approval rejections

### DIFF
--- a/src/Payments.Emails/EmailService.cs
+++ b/src/Payments.Emails/EmailService.cs
@@ -22,6 +22,10 @@ namespace Payments.Emails
 
         Task SendFinancialApprove(Invoice invoice, SendApprovalModel approvalModel);
 
+        Task SendFinancialApprovalRejectedCustomer(Invoice invoice, string rejectionReason, User financialApprover);
+
+        Task SendFinancialApprovalRejectedEditors(Invoice invoice, string rejectionReason, IReadOnlyCollection<User> editors);
+
         Task SendReceipt(Invoice invoice, PaymentEvent payment);
 
         Task SendRechargeReceipt(Invoice invoice, SendApprovalModel approvalModel);
@@ -251,6 +255,68 @@ namespace Payments.Emails
                 }
 
                 // ship it
+                await _client.SendMailAsync(message);
+                Log.Information("Sent Email");
+            }
+        }
+
+        public async Task SendFinancialApprovalRejectedCustomer(Invoice invoice, string rejectionReason, User financialApprover)
+        {
+            var viewbag = GetViewData();
+            viewbag["Team"] = invoice.Team;
+            viewbag["Invoice"] = invoice;
+
+            var model = new FinancialApprovalRejectedViewModel
+            {
+                Invoice = invoice,
+                RejectionReason = rejectionReason,
+            };
+
+            var prehtml = await RazorTemplateEngine.RenderAsync("/Views/FinancialApprovalRejectedCustomer.cshtml", model, viewbag);
+            var mjml = await _mjmlServices.Render(prehtml);
+
+            using (var message = new MailMessage { From = _fromAddress, Subject = $"Recharge invoice {invoice.GetFormattedId()} rejected" })
+            {
+                message.Body = mjml.Html;
+                message.IsBodyHtml = true;
+                message.To.Add(new MailAddress(invoice.CustomerEmail, invoice.CustomerName));
+                message.CC.Add(new MailAddress(financialApprover.Email, financialApprover.Name));
+
+                await _client.SendMailAsync(message);
+                Log.Information("Sent Email");
+            }
+        }
+
+        public async Task SendFinancialApprovalRejectedEditors(Invoice invoice, string rejectionReason, IReadOnlyCollection<User> editors)
+        {
+            if (editors == null || editors.Count == 0)
+            {
+                return;
+            }
+
+            var viewbag = GetViewData();
+            viewbag["Team"] = invoice.Team;
+            viewbag["Invoice"] = invoice;
+
+            var model = new FinancialApprovalRejectedViewModel
+            {
+                Invoice = invoice,
+                RejectionReason = rejectionReason,
+            };
+
+            var prehtml = await RazorTemplateEngine.RenderAsync("/Views/FinancialApprovalRejectedEditors.cshtml", model, viewbag);
+            var mjml = await _mjmlServices.Render(prehtml);
+
+            using (var message = new MailMessage { From = _fromAddress, Subject = $"Recharge invoice {invoice.GetFormattedId()} rejected" })
+            {
+                message.Body = mjml.Html;
+                message.IsBodyHtml = true;
+
+                foreach (var editor in editors)
+                {
+                    message.To.Add(new MailAddress(editor.Email, editor.Name));
+                }
+
                 await _client.SendMailAsync(message);
                 Log.Information("Sent Email");
             }

--- a/src/Payments.Emails/Models/FinancialApprovalRejectedViewModel.cs
+++ b/src/Payments.Emails/Models/FinancialApprovalRejectedViewModel.cs
@@ -1,0 +1,11 @@
+using Payments.Core.Domain;
+
+namespace Payments.Emails.Models
+{
+    public class FinancialApprovalRejectedViewModel
+    {
+        public Invoice Invoice { get; set; }
+
+        public string RejectionReason { get; set; }
+    }
+}

--- a/src/Payments.Emails/Views/FinancialApprovalRejectedCustomer.cshtml
+++ b/src/Payments.Emails/Views/FinancialApprovalRejectedCustomer.cshtml
@@ -1,0 +1,27 @@
+@using Payments.Core.Domain
+@model Payments.Emails.Models.FinancialApprovalRejectedViewModel
+
+@{
+    Layout = "_EmailLayout";
+    var team = (Team)ViewData["Team"];
+    var invoice = Model.Invoice;
+    var invoiceHref = $"{ViewData["BaseUrl"]}/recharge/pay/{invoice.LinkId}";
+    var pdfHref = $"{ViewData["BaseUrl"]}/download/{invoice.LinkId}";
+}
+
+<mj-text align="center">
+    <h1>Recharge invoice rejected</h1>
+    <h3>Invoice # @invoice.GetFormattedId() from @team.Name</h3>
+</mj-text>
+
+<mj-text>
+    <p>A financial approver rejected this invoice.</p>
+    <p style="font-weight: bold">Reason:</p>
+    <p>@Model.RejectionReason</p>
+</mj-text>
+
+<mj-button href="@invoiceHref" background-color="#004987">View this Invoice</mj-button>
+
+@{ await Html.PartialAsync("_EmailSummary", invoice); }
+
+<mj-button href="@pdfHref" background-color="#004987">Download as PDF</mj-button>

--- a/src/Payments.Emails/Views/FinancialApprovalRejectedEditors.cshtml
+++ b/src/Payments.Emails/Views/FinancialApprovalRejectedEditors.cshtml
@@ -1,0 +1,22 @@
+@using Payments.Core.Domain
+@model Payments.Emails.Models.FinancialApprovalRejectedViewModel
+
+@{
+    Layout = "_EmailLayout";
+    var team = (Team)ViewData["Team"];
+    var invoice = Model.Invoice;
+    var detailsHref = $"{ViewData["BaseUrl"]}/{team.Slug}/Invoices/Details/{invoice.Id}";
+}
+
+<mj-text align="center">
+    <h1>Recharge invoice rejected</h1>
+    <h3>Invoice # @invoice.GetFormattedId() from @team.Name</h3>
+</mj-text>
+
+<mj-text>
+    <p>A financial approver rejected this invoice.</p>
+    <p style="font-weight: bold">Reason:</p>
+    <p>@Model.RejectionReason</p>
+</mj-text>
+
+<mj-button href="@detailsHref" background-color="#004987">View Invoice Details</mj-button>

--- a/src/Payments.Mvc/Controllers/RechargeController.cs
+++ b/src/Payments.Mvc/Controllers/RechargeController.cs
@@ -502,11 +502,9 @@ namespace Payments.Mvc.Controllers
                     Data = rejectReason
                 };
                 invoice.History.Add(actionEntry);
-                //_dbContext.Invoices.Update(invoice);
                 await _dbContext.SaveChangesAsync();
 
-                //Send rejection email?
-
+                await _invoiceService.SendFinancialApprovalRejected(invoice, rejectReason, user);
 
                 return Ok();
             }

--- a/src/Payments.Mvc/Services/InvoiceService.cs
+++ b/src/Payments.Mvc/Services/InvoiceService.cs
@@ -8,6 +8,7 @@ using Payments.Core.Models.Validation;
 using Payments.Core.Resources;
 using Payments.Core.Services;
 using Payments.Emails;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -658,6 +659,38 @@ namespace Payments.Mvc.Services
             return model;
         }
 
+        public async Task SendFinancialApprovalRejected(Invoice invoice, string rejectionReason, User financialApprover)
+        {
+            try
+            {
+                await _emailService.SendFinancialApprovalRejectedCustomer(invoice, rejectionReason, financialApprover);
+            }
+            catch (Exception exception)
+            {
+                Log.Error(exception, "Failed to send financial approval rejection email to the customer for invoice {InvoiceId}", invoice.Id);
+            }
+
+            try
+            {
+                var editors = await _dbContext.TeamPermissions
+                    .Where(permission => permission.TeamId == invoice.Team.Id && permission.Role.Name == TeamRole.Codes.Editor)
+                    .Select(permission => permission.User)
+                    .ToListAsync();
+
+                var distinctEditors = editors
+                    .Where(editor => !string.IsNullOrWhiteSpace(editor.Email))
+                    .GroupBy(editor => editor.Email, StringComparer.OrdinalIgnoreCase)
+                    .Select(group => group.First())
+                    .ToArray();
+
+                await _emailService.SendFinancialApprovalRejectedEditors(invoice, rejectionReason, distinctEditors);
+            }
+            catch (Exception exception)
+            {
+                Log.Error(exception, "Failed to send financial approval rejection email to team editors for invoice {InvoiceId}", invoice.Id);
+            }
+        }
+
         private async Task<SendApprovalModel> GetInvoiceApprovers(Invoice invoice)
         {
             if(invoice.RechargeAccounts == null || !invoice.RechargeAccounts.Any(a => a.Direction == RechargeAccount.CreditDebit.Debit))
@@ -845,6 +878,8 @@ namespace Payments.Mvc.Services
         Task SendRechargeReceipt(Invoice invoice);
 
         Task<SendApprovalModel> SendFinancialApproverEmail(Invoice invoice, SendApprovalModel model);
+
+        Task SendFinancialApprovalRejected(Invoice invoice, string rejectionReason, User financialApprover);
 
         Task RefundInvoice(Invoice invoice, PaymentEvent payment, string refundReason, User user);
 

--- a/tests/Payments.Tests/EmailTests/FinancialApprovalRejectedEmailTests.cs
+++ b/tests/Payments.Tests/EmailTests/FinancialApprovalRejectedEmailTests.cs
@@ -1,0 +1,95 @@
+using Microsoft.Extensions.DependencyInjection;
+using Mjml.AspNetCore;
+using Payments.Core.Domain;
+using Payments.Emails.Models;
+using Razor.Templating.Core;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace payments.Tests.EmailTests
+{
+    public class FinancialApprovalRejectedEmailTests
+    {
+        [Fact]
+        public async Task CustomerTemplate_RendersReasonAndPublicInvoiceLinks()
+        {
+            var invoice = CreateInvoice();
+            var html = await Render(
+                "/Views/FinancialApprovalRejectedCustomer.cshtml",
+                invoice,
+                "The debit account is incorrect.");
+
+            Assert.Contains("The debit account is incorrect.", html);
+            Assert.Contains("https://payments.example/recharge/pay/invoice-link", html);
+            Assert.Contains("https://payments.example/download/invoice-link", html);
+            Assert.DoesNotContain("<mj-", html);
+        }
+
+        [Fact]
+        public async Task EditorsTemplate_RendersReasonAndInvoiceDetailsLink()
+        {
+            var invoice = CreateInvoice();
+            var html = await Render(
+                "/Views/FinancialApprovalRejectedEditors.cshtml",
+                invoice,
+                "The debit account is incorrect.");
+
+            Assert.Contains("The debit account is incorrect.", html);
+            Assert.Contains("https://payments.example/test-team/Invoices/Details/42", html);
+            Assert.DoesNotContain("<mj-", html);
+        }
+
+        private static Invoice CreateInvoice()
+        {
+            return new Invoice
+            {
+                Id = 42,
+                LinkId = "invoice-link",
+                CustomerEmail = "customer@example.com",
+                CustomerName = "Customer",
+                Team = new Team
+                {
+                    Id = 7,
+                    Name = "Test Team",
+                    Slug = "test-team",
+                    ContactEmail = "team@example.com",
+                    ContactPhoneNumber = "530-555-0100",
+                },
+                Items = new List<LineItem>
+                {
+                    new LineItem
+                    {
+                        Description = "Service",
+                        Quantity = 1,
+                        Total = 25,
+                    },
+                },
+            };
+        }
+
+        private static async Task<string> Render(string viewPath, Invoice invoice, string rejectionReason)
+        {
+            var viewData = new Dictionary<string, object>
+            {
+                { "BaseUrl", "https://payments.example" },
+                { "Team", invoice.Team },
+                { "Invoice", invoice },
+            };
+            var model = new FinancialApprovalRejectedViewModel
+            {
+                Invoice = invoice,
+                RejectionReason = rejectionReason,
+            };
+            var mjmlMarkup = await RazorTemplateEngine.RenderAsync(viewPath, model, viewData);
+
+            var services = new ServiceCollection();
+            services.AddMjmlServices();
+            using var serviceProvider = services.BuildServiceProvider();
+            var renderer = serviceProvider.GetRequiredService<IMjmlServices>();
+            var response = await renderer.Render(mjmlMarkup);
+
+            return response.Html;
+        }
+    }
+}

--- a/tests/Payments.Tests/ServiceTests/InvoiceServiceTests.cs
+++ b/tests/Payments.Tests/ServiceTests/InvoiceServiceTests.cs
@@ -175,5 +175,127 @@ namespace payments.Tests.ServiceTests
             Assert.Equal(0, invoice.CalculatedTotal);
             Assert.Equal(PaymentTypes.Coupon, invoice.PaymentType);
         }
+
+        [Fact]
+        public async Task SendFinancialApprovalRejected_SendsCustomerAndDistinctTeamEditors()
+        {
+            var team = new Team { Id = 7, Name = "Test Team", Slug = "test-team" };
+            var invoice = new Invoice
+            {
+                Id = 42,
+                Team = team,
+                CustomerEmail = "customer@example.com",
+                CustomerName = "Customer",
+            };
+            var approver = new User
+            {
+                Id = "approver",
+                Email = "approver@example.com",
+                Name = "Financial Approver",
+            };
+            var editorRole = new TeamRole { Name = TeamRole.Codes.Editor };
+            var permissions = new List<TeamPermission>
+            {
+                new TeamPermission
+                {
+                    TeamId = team.Id,
+                    Role = editorRole,
+                    User = new User { Id = "editor-1", Email = "editor1@example.com", Name = "Editor One" },
+                },
+                new TeamPermission
+                {
+                    TeamId = team.Id,
+                    Role = editorRole,
+                    User = new User { Id = "duplicate-editor", Email = "EDITOR1@example.com", Name = "Duplicate Editor" },
+                },
+                new TeamPermission
+                {
+                    TeamId = team.Id,
+                    Role = editorRole,
+                    User = new User { Id = "editor-2", Email = "editor2@example.com", Name = "Editor Two" },
+                },
+                new TeamPermission
+                {
+                    TeamId = team.Id,
+                    Role = new TeamRole { Name = TeamRole.Codes.Admin },
+                    User = new User { Id = "admin", Email = "admin@example.com", Name = "Admin" },
+                },
+                new TeamPermission
+                {
+                    TeamId = 99,
+                    Role = editorRole,
+                    User = new User { Id = "other-team", Email = "other@example.com", Name = "Other Team Editor" },
+                },
+            };
+            var dbContext = new Mock<ApplicationDbContext>(new DbContextOptions<ApplicationDbContext>());
+            dbContext
+                .Setup(context => context.TeamPermissions)
+                .Returns(permissions.AsQueryable().MockAsyncDbSet().Object);
+            var emailService = new Mock<IEmailService>();
+            var service = new InvoiceService(
+                dbContext.Object,
+                emailService.Object,
+                new Mock<IAggieEnterpriseService>().Object);
+
+            await service.SendFinancialApprovalRejected(invoice, "Incorrect account", approver);
+
+            emailService.Verify(
+                email => email.SendFinancialApprovalRejectedCustomer(invoice, "Incorrect account", approver),
+                Times.Once);
+            emailService.Verify(
+                email => email.SendFinancialApprovalRejectedEditors(
+                    invoice,
+                    "Incorrect account",
+                    It.Is<IReadOnlyCollection<User>>(editors =>
+                        editors.Count == 2 &&
+                        editors.Any(editor => editor.Email == "editor1@example.com") &&
+                        editors.Any(editor => editor.Email == "editor2@example.com"))),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task SendFinancialApprovalRejected_CustomerFailureStillAttemptsEditorsAndDoesNotThrow()
+        {
+            var team = new Team { Id = 7 };
+            var invoice = new Invoice { Id = 42, Team = team };
+            var approver = new User { Email = "approver@example.com", Name = "Financial Approver" };
+            var editor = new User { Email = "editor@example.com", Name = "Editor" };
+            var permissions = new List<TeamPermission>
+            {
+                new TeamPermission
+                {
+                    TeamId = team.Id,
+                    Role = new TeamRole { Name = TeamRole.Codes.Editor },
+                    User = editor,
+                },
+            };
+            var dbContext = new Mock<ApplicationDbContext>(new DbContextOptions<ApplicationDbContext>());
+            dbContext
+                .Setup(context => context.TeamPermissions)
+                .Returns(permissions.AsQueryable().MockAsyncDbSet().Object);
+            var emailService = new Mock<IEmailService>();
+            emailService
+                .Setup(email => email.SendFinancialApprovalRejectedCustomer(invoice, "Incorrect account", approver))
+                .ThrowsAsync(new InvalidOperationException("SMTP unavailable"));
+            emailService
+                .Setup(email => email.SendFinancialApprovalRejectedEditors(
+                    invoice,
+                    "Incorrect account",
+                    It.IsAny<IReadOnlyCollection<User>>()))
+                .ThrowsAsync(new InvalidOperationException("SMTP unavailable"));
+            var service = new InvoiceService(
+                dbContext.Object,
+                emailService.Object,
+                new Mock<IAggieEnterpriseService>().Object);
+
+            await service.SendFinancialApprovalRejected(invoice, "Incorrect account", approver);
+
+            emailService.Verify(
+                email => email.SendFinancialApprovalRejectedEditors(
+                    invoice,
+                    "Incorrect account",
+                    It.Is<IReadOnlyCollection<User>>(editors => editors.Count == 1 && editors.Single() == editor)),
+                Times.Once);
+        }
     }
 }


### PR DESCRIPTION
Notifies both the customer and the relevant team editors with the reason for the rejection.