### PR TITLE
Ensure invoice total is rounded to two decimal places

### DIFF
--- a/src/Payments.Core/Domain/Invoice.cs
+++ b/src/Payments.Core/Domain/Invoice.cs
@@ -223,7 +223,8 @@ namespace Payments.Core.Domain
 
             CalculatedTaxAmount = GetTaxAmount();
 
-            CalculatedTotal = Math.Max(CalculatedSubtotal - CalculatedDiscount + CalculatedTaxAmount, 0);
+            //Now that we sum everything, now we round the total
+            CalculatedTotal = Math.Round(Math.Max(CalculatedSubtotal - CalculatedDiscount + CalculatedTaxAmount, 0m), 2, MidpointRounding.AwayFromZero);
         }
 
         protected internal static void OnModelCreating(ModelBuilder builder)

--- a/src/Payments.Mvc/ClientApp/src/components/rechargeAccountsControl.tsx
+++ b/src/Payments.Mvc/ClientApp/src/components/rechargeAccountsControl.tsx
@@ -8,6 +8,10 @@ import {
 import CurrencyControl from './currencyControl';
 import NumberControl from './numberControl';
 import { formatCurrencyLocale } from '../utils/currency';
+import {
+  calculatePercentageAmount,
+  roundCurrency
+} from '../helpers/calculations';
 
 interface IProps {
   rechargeAccounts: InvoiceRechargeItem[];
@@ -771,10 +775,9 @@ export default class RechargeAccountsControl extends React.Component<
           };
         } else if (field === 'percentage' && value >= 0 && value <= 100) {
           // Calculate amount when percentage changes
-          const amount = (value / 100) * this.props.invoiceTotal;
           updatedAccounts[index] = {
             ...updatedAccounts[index],
-            amount: parseFloat(amount.toFixed(2))
+            amount: calculatePercentageAmount(this.props.invoiceTotal, value)
           };
         }
 
@@ -838,10 +841,9 @@ export default class RechargeAccountsControl extends React.Component<
           };
         } else if (field === 'percentage' && value >= 0 && value <= 100) {
           // Calculate amount when percentage changes
-          const amount = (value / 100) * this.props.invoiceTotal;
           updatedAccounts[index] = {
             ...updatedAccounts[index],
-            amount: parseFloat(amount.toFixed(2))
+            amount: calculatePercentageAmount(this.props.invoiceTotal, value)
           };
         }
 
@@ -955,16 +957,12 @@ export default class RechargeAccountsControl extends React.Component<
 
   private calculateTotal = (accounts: InvoiceRechargeItem[]): number => {
     const total = accounts.reduce((sum, account) => sum + account.amount, 0);
-    // Round to 2 decimal places to handle floating point precision issues
-    return parseFloat(total.toFixed(2));
+    return roundCurrency(total);
   };
 
   // Helper method to compare monetary amounts with proper rounding
   private isTotalEqual = (total: number, expected: number): boolean => {
-    // Round both values to 2 decimal places before comparison
-    const roundedTotal = parseFloat(total.toFixed(2));
-    const roundedExpected = parseFloat(expected.toFixed(2));
-    return roundedTotal === roundedExpected;
+    return roundCurrency(total) === roundCurrency(expected);
   };
 
   private renderValidationMessages = (account: InvoiceRechargeItem) => {

--- a/src/Payments.Mvc/ClientApp/src/helpers/calculations.test.ts
+++ b/src/Payments.Mvc/ClientApp/src/helpers/calculations.test.ts
@@ -1,0 +1,49 @@
+import {
+  calculatePercentageAmount,
+  calculateTotal,
+  roundCurrency
+} from './calculations';
+
+describe('currency calculations', () => {
+  it.each([
+    [9.349, 9.35],
+    [9.344, 9.34],
+    [9.345, 9.35]
+  ])('rounds %s to %s', (value, expected) => {
+    expect(roundCurrency(value)).toBe(expected);
+  });
+
+  it('rounds the final invoice total to currency precision', () => {
+    const items = [
+      {
+        id: 1,
+        description: 'Recharge item',
+        quantity: 0.25,
+        amount: 10.02,
+        taxExempt: false,
+        total: 0
+      }
+    ];
+
+    expect(calculateTotal(items, { hasDiscount: false }, 0)).toBe(2.51);
+  });
+
+  it('uses the rounded invoice total for a 100 percent allocation', () => {
+    const invoiceTotal = calculateTotal(
+      [
+        {
+          id: 1,
+          description: 'Recharge item',
+          quantity: 0.25,
+          amount: 10.02,
+          taxExempt: false,
+          total: 0
+        }
+      ],
+      { hasDiscount: false },
+      0
+    );
+
+    expect(calculatePercentageAmount(invoiceTotal, 100)).toBe(2.51);
+  });
+});

--- a/src/Payments.Mvc/ClientApp/src/helpers/calculations.test.ts
+++ b/src/Payments.Mvc/ClientApp/src/helpers/calculations.test.ts
@@ -13,37 +13,77 @@ describe('currency calculations', () => {
     expect(roundCurrency(value)).toBe(expected);
   });
 
-  it('rounds the final invoice total to currency precision', () => {
+  it.each([
+    [0.06, 155.5, 9.33],
+    [0.06, 155.83, 9.35],
+    [0.06, 155.74, 9.34],
+    [0.25, 10.02, 2.51],
+    [0.01, 10.5, 0.11]
+  ])(
+    'rounds quantity %s at unit price %s to invoice total %s',
+    (quantity, amount, expected) => {
+      const items = [
+        {
+          id: 1,
+          description: 'Recharge item',
+          quantity,
+          amount,
+          taxExempt: false,
+          total: 0
+        }
+      ];
+
+      expect(calculateTotal(items, { hasDiscount: false }, 0)).toBe(expected);
+    }
+  );
+
+  it('rounds the combined total after summing all line items', () => {
     const items = [
       {
         id: 1,
         description: 'Recharge item',
-        quantity: 0.25,
-        amount: 10.02,
+        quantity: 0.06,
+        amount: 155.83,
+        taxExempt: false,
+        total: 0
+      },
+      {
+        id: 2,
+        description: 'Rounding adjustment item',
+        quantity: 0.01,
+        amount: 0.02,
         taxExempt: false,
         total: 0
       }
     ];
 
-    expect(calculateTotal(items, { hasDiscount: false }, 0)).toBe(2.51);
+    expect(calculateTotal(items, { hasDiscount: false }, 0)).toBe(9.35);
   });
 
-  it('uses the rounded invoice total for a 100 percent allocation', () => {
-    const invoiceTotal = calculateTotal(
-      [
-        {
-          id: 1,
-          description: 'Recharge item',
-          quantity: 0.25,
-          amount: 10.02,
-          taxExempt: false,
-          total: 0
-        }
-      ],
-      { hasDiscount: false },
-      0
-    );
+  it.each([
+    [0.06, 155.83, 9.35],
+    [0.06, 155.74, 9.34],
+    [0.25, 10.02, 2.51],
+    [0.01, 10.5, 0.11]
+  ])(
+    'uses rounded total %s x %s for a 100 percent recharge allocation',
+    (quantity, amount, expected) => {
+      const invoiceTotal = calculateTotal(
+        [
+          {
+            id: 1,
+            description: 'Recharge item',
+            quantity,
+            amount,
+            taxExempt: false,
+            total: 0
+          }
+        ],
+        { hasDiscount: false },
+        0
+      );
 
-    expect(calculatePercentageAmount(invoiceTotal, 100)).toBe(2.51);
-  });
+      expect(calculatePercentageAmount(invoiceTotal, 100)).toBe(expected);
+    }
+  );
 });

--- a/src/Payments.Mvc/ClientApp/src/helpers/calculations.ts
+++ b/src/Payments.Mvc/ClientApp/src/helpers/calculations.ts
@@ -3,6 +3,17 @@ import { isAfter } from 'date-fns';
 import { InvoiceDiscount } from "../models/InvoiceDiscount";
 import { InvoiceItem } from "../models/InvoiceItem";
 
+export function roundCurrency(value: number) {
+    const absoluteValue = Math.abs(value);
+    const roundedValue = Math.round((absoluteValue + Number.EPSILON) * 100) / 100;
+
+    return Math.sign(value) * roundedValue;
+}
+
+export function calculatePercentageAmount(total: number, percentage: number) {
+    return roundCurrency((percentage / 100) * total);
+}
+
 export function calculateSubTotal(items: InvoiceItem[]) {
     const sum = items.reduce((prev, item) => {
         return prev + (item.quantity * item.amount);
@@ -72,5 +83,5 @@ export function calculateTotal(items: InvoiceItem[], discount: InvoiceDiscount, 
     const totalDiscount = calculateDiscount(items, discount);
     const sub = calculateSubTotal(items);
     const tax = calculateTaxAmount(items, discount, taxPercent);
-    return sub - totalDiscount + tax;
+    return roundCurrency(Math.max(sub - totalDiscount + tax, 0));
 }

--- a/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
@@ -252,12 +252,12 @@ namespace Payments.Tests.DatabaseTests
         [InlineData(0, 0, 3.72)]
         [InlineData(1, 0, 2.72)]
         [InlineData(2, 0, 1.72)]
-        [InlineData(0, 0.15, 4.278)]
-        [InlineData(0, 0.10, 4.092)]
-        [InlineData(1, 0.15, 3.128)]
-        [InlineData(1, 0.10, 2.992)]
-        [InlineData(1.5, 0.15, 2.553)]
-        [InlineData(1.5, 0.10, 2.442)]
+        [InlineData(0, 0.15, 4.28)]
+        [InlineData(0, 0.10, 4.09)]
+        [InlineData(1, 0.15, 3.13)]
+        [InlineData(1, 0.10, 2.99)]
+        [InlineData(1.5, 0.15, 2.55)]
+        [InlineData(1.5, 0.10, 2.44)]
         public void TestUpdateCalculatedValuesUpdatesTotal(decimal discount, decimal taxPercent, decimal expectedValue)
         {
             // Arrange
@@ -279,11 +279,11 @@ namespace Payments.Tests.DatabaseTests
         [InlineData(0, 0, 3.72)]
         [InlineData(1, 0, 2.72)]
         [InlineData(2, 0, 1.72)]
-        [InlineData(0, 0.15, 4.092)]
-        [InlineData(0, 0.10, 3.968)]
-        [InlineData(1, 0.15, 2.992)]
-        [InlineData(1.5, 0.15, 2.442)]
-        [InlineData(1.5, 0.10, 2.368)]
+        [InlineData(0, 0.15, 4.09)]
+        [InlineData(0, 0.10, 3.97)]
+        [InlineData(1, 0.15, 2.99)]
+        [InlineData(1.5, 0.15, 2.44)]
+        [InlineData(1.5, 0.10, 2.37)]
         public void TestUpdateCalculatedValuesWithTaxExemptUpdatesTotal(decimal discount, decimal taxPercent, decimal expectedValue)
         {
             // Arrange

--- a/tests/Payments.Tests/ServiceTests/InvoiceServiceTests.cs
+++ b/tests/Payments.Tests/ServiceTests/InvoiceServiceTests.cs
@@ -298,5 +298,97 @@ namespace payments.Tests.ServiceTests
                     It.Is<IReadOnlyCollection<User>>(editors => editors.Count == 1 && editors.Single() == editor)),
                 Times.Once);
         }
+
+        [Theory]
+        [InlineData(0.06, 155.50, 9.33)]
+        [InlineData(0.06, 155.83, 9.35)]
+        [InlineData(0.06, 155.74, 9.34)]
+        [InlineData(0.25, 10.02, 2.51)]
+        [InlineData(0.01, 10.50, 0.11)]
+        public async Task CreateInvoices_AcceptsCreditRechargeTotalRoundedToDisplayedCurrencyAmount(
+            decimal quantity,
+            decimal unitPrice,
+            decimal expectedTotal)
+        {
+            var (service, model, team) = CreateRechargeInvoiceServiceTest(quantity, unitPrice, expectedTotal);
+
+            var invoices = await service.CreateInvoices(model, team);
+
+            var invoice = Assert.Single(invoices);
+            Assert.Equal(expectedTotal, invoice.CalculatedTotal);
+            Assert.Equal(expectedTotal, Assert.Single(invoice.RechargeAccounts).Amount);
+        }
+
+        [Fact]
+        public async Task CreateInvoices_RejectsCreditRechargeTotalThatDiffersByOneCent()
+        {
+            var (service, model, team) = CreateRechargeInvoiceServiceTest(0.06m, 155.83m, 9.34m);
+
+            var exception = await Assert.ThrowsAsync<ArgumentException>(
+                () => service.CreateInvoices(model, team));
+
+            Assert.Equal(nameof(model.RechargeAccounts), exception.ParamName);
+            Assert.Contains("Total of credit recharge accounts must equal invoice total.", exception.Message);
+        }
+
+        private static (InvoiceService service, CreateInvoiceModel model, Team team) CreateRechargeInvoiceServiceTest(
+            decimal quantity,
+            decimal unitPrice,
+            decimal rechargeAmount)
+        {
+            const string chartString = "valid-chart-string";
+            var dbContext = new Mock<ApplicationDbContext>(new DbContextOptions<ApplicationDbContext>());
+            dbContext
+                .Setup(context => context.FinancialAccounts)
+                .Returns(new List<FinancialAccount>().AsQueryable().MockAsyncDbSet().Object);
+            dbContext
+                .Setup(context => context.Invoices)
+                .Returns(new Mock<DbSet<Invoice>>().Object);
+
+            var aggieEnterpriseService = new Mock<IAggieEnterpriseService>();
+            aggieEnterpriseService
+                .Setup(service => service.IsRechargeAccountValid(
+                    chartString, RechargeAccount.CreditDebit.Credit, true))
+                .ReturnsAsync(new AccountValidationModel
+                {
+                    IsValid = true,
+                    ChartString = chartString,
+                });
+
+            var service = new InvoiceService(
+                dbContext.Object,
+                new Mock<IEmailService>().Object,
+                aggieEnterpriseService.Object);
+            var model = new CreateInvoiceModel
+            {
+                Type = Invoice.InvoiceTypes.Recharge,
+                Customers = new List<CreateInvoiceCustomerModel>
+                {
+                    new CreateInvoiceCustomerModel { Email = "customer@example.com" },
+                },
+                Items = new List<CreateInvoiceItemModel>
+                {
+                    new CreateInvoiceItemModel
+                    {
+                        Description = "Reported rounding case",
+                        Quantity = quantity,
+                        Amount = unitPrice,
+                    },
+                },
+                Attachments = new List<CreateInvoiceAttachmentModel>(),
+                RechargeAccounts = new List<RechargeAccount>
+                {
+                    new RechargeAccount
+                    {
+                        Direction = RechargeAccount.CreditDebit.Credit,
+                        FinancialSegmentString = chartString,
+                        Amount = rechargeAmount,
+                        Percentage = 100m,
+                    },
+                },
+            };
+
+            return (service, model, new Team { Id = 1 });
+        }
     }
 }


### PR DESCRIPTION
Applies explicit rounding to the final calculated total using `Math.Round` to maintain financial accuracy and consistency for currency amounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice calculated totals are now rounded to two decimal places using consistent midpoint rounding.
  * Negative calculated totals continue to be prevented by clamping them to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->