### PR TITLE
Add right padding to dismissible alerts

### DIFF
--- a/src/Payments.Mvc/ClientApp/src/css/_components.scss
+++ b/src/Payments.Mvc/ClientApp/src/css/_components.scss
@@ -13,6 +13,11 @@ button {
 }
 .alert {
   padding: $card-padding;
+
+  &.alert-dismissible {
+    padding-right: 3rem;
+  }
+
   p {
     margin-bottom: 0px;
     color: $secondary-font;


### PR DESCRIPTION
This provides adequate space for the close button, preventing content from overlapping.