### PR TITLE
Jcs/more rounding fixes

### DIFF
--- a/src/Payments.Core/Domain/Invoice.cs
+++ b/src/Payments.Core/Domain/Invoice.cs
@@ -210,7 +210,7 @@ namespace Payments.Core.Domain
         public decimal GetTaxAmount()
         {
             var taxableTotal = GetTaxableTotal();
-            return taxableTotal * TaxPercent;
+            return Math.Round(taxableTotal * TaxPercent, 2, MidpointRounding.AwayFromZero);
         }
 
         public void UpdateCalculatedValues()

--- a/src/Payments.Core/Domain/Invoice.cs
+++ b/src/Payments.Core/Domain/Invoice.cs
@@ -187,7 +187,7 @@ namespace Payments.Core.Domain
                 return Coupon.DiscountAmount ?? 0;
             }
 
-            var subTotal = Items.Sum(i => i.Total);
+            var subTotal = Items.Sum(i => i.Quantity * i.Amount);
             if (Coupon.DiscountPercent.HasValue)
             {
                 return Coupon.DiscountPercent * subTotal ?? 0;
@@ -198,11 +198,11 @@ namespace Payments.Core.Domain
 
         public decimal GetTaxableTotal()
         {
-            var subtotal = Items.Sum(i => i.Total);
+            var subtotal = Items.Sum(i => i.Quantity * i.Amount);
             var discount = GetDiscountAmount();
 
             // remove tax exempt items, apply proportional part of discount, then calculate tax
-            var taxableAmount = Items.Where(i => !i.TaxExempt).Sum(i => i.Total);
+            var taxableAmount = Items.Where(i => !i.TaxExempt).Sum(i => i.Quantity * i.Amount);
             var taxableDiscount = discount * (taxableAmount / subtotal);
             return (taxableAmount - taxableDiscount);
         }
@@ -215,7 +215,7 @@ namespace Payments.Core.Domain
 
         public void UpdateCalculatedValues()
         {
-            CalculatedSubtotal = Items.Sum(i => i.Total);
+            CalculatedSubtotal = Items.Sum(i => i.Quantity * i.Amount);
 
             CalculatedDiscount = GetDiscountAmount();
 

--- a/src/Payments.Mvc/ClientApp/src/helpers/calculations.test.ts
+++ b/src/Payments.Mvc/ClientApp/src/helpers/calculations.test.ts
@@ -1,5 +1,6 @@
 import {
   calculatePercentageAmount,
+  calculateTaxAmount,
   calculateTotal,
   roundCurrency
 } from './calculations';
@@ -58,6 +59,21 @@ describe('currency calculations', () => {
     ];
 
     expect(calculateTotal(items, { hasDiscount: false }, 0)).toBe(9.35);
+  });
+
+  it('rounds tax before calculating the invoice total', () => {
+    const items = [1, 2, 3].map(id => ({
+      id,
+      description: 'Taxable item',
+      quantity: 0.06,
+      amount: 155.74,
+      taxExempt: false,
+      total: 9.34
+    }));
+    const discount = { hasDiscount: false };
+
+    expect(calculateTaxAmount(items, discount, 0.07)).toBe(1.96);
+    expect(calculateTotal(items, discount, 0.07)).toBe(29.99);
   });
 
   it.each([

--- a/src/Payments.Mvc/ClientApp/src/helpers/calculations.ts
+++ b/src/Payments.Mvc/ClientApp/src/helpers/calculations.ts
@@ -75,7 +75,7 @@ export function calculateTaxAmount(items: InvoiceItem[], discount: InvoiceDiscou
 
     const taxableDiscount = totalDiscount * (taxableSub / sub);
 
-    return (taxableSub - taxableDiscount) * taxPercent;
+    return roundCurrency((taxableSub - taxableDiscount) * taxPercent);
 }
 
 export function calculateTotal(items: InvoiceItem[], discount: InvoiceDiscount, taxPercent: number) {

--- a/tests/Payments.Tests/ControllerTests/PaymentsControllerTests.cs
+++ b/tests/Payments.Tests/ControllerTests/PaymentsControllerTests.cs
@@ -42,7 +42,7 @@ namespace payments.Tests.ControllerTests
                 Coupon = new Coupon { DiscountAmount = 10 },
                 Items = new List<LineItem>
                 {
-                    new LineItem { Total = 10 },
+                    new LineItem { Amount = 10, Quantity = 1, Total = 10 },
                 },
             };
 

--- a/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
@@ -196,32 +196,34 @@ namespace Payments.Tests.DatabaseTests
         }
 
         [Fact]
-        public void TestUpdateCalculatedValuesUsesUnroundedLineItemTotals()
+        public void TestUpdateCalculatedValuesUsesUnroundedLineItemTotalsAndRoundedTax()
         {
             // Arrange
             var invoice = new Invoice();
             invoice.Items.Add(new LineItem() { Amount = 155.74m, Quantity = 0.06m, Total = 9.34m });
             invoice.Items.Add(new LineItem() { Amount = 155.74m, Quantity = 0.06m, Total = 9.34m });
             invoice.Items.Add(new LineItem() { Amount = 155.74m, Quantity = 0.06m, Total = 9.34m });
+            invoice.TaxPercent = 0.07m;
 
             // Act
             invoice.UpdateCalculatedValues();
 
             // Assert
             invoice.CalculatedSubtotal.ShouldBe(28.0332m);
-            invoice.CalculatedTotal.ShouldBe(28.03m);
+            invoice.CalculatedTaxAmount.ShouldBe(1.96m);
+            invoice.CalculatedTotal.ShouldBe(29.99m);
         }
 
         [Theory]
         [InlineData(0, 0, 0)]
         [InlineData(1, 0, 0)]
         [InlineData(2, 0, 0)]
-        [InlineData(0, 0.15, 0.558)]
-        [InlineData(0, 0.10, 0.372)]
-        [InlineData(1, 0.15, 0.408)]
-        [InlineData(1, 0.10, 0.272)]
-        [InlineData(1.5, 0.15, 0.333)]
-        [InlineData(1.5, 0.10, 0.222)]
+        [InlineData(0, 0.15, 0.56)]
+        [InlineData(0, 0.10, 0.37)]
+        [InlineData(1, 0.15, 0.41)]
+        [InlineData(1, 0.10, 0.27)]
+        [InlineData(1.5, 0.15, 0.33)]
+        [InlineData(1.5, 0.10, 0.22)]
         public void TestUpdateCalculatedValuesUpdatesTaxAmount(decimal discount, decimal taxPercent, decimal expectedValue)
         {
             // Arrange
@@ -243,11 +245,11 @@ namespace Payments.Tests.DatabaseTests
         [InlineData(0, 0, 0)]
         [InlineData(1, 0, 0)]
         [InlineData(2, 0, 0)]
-        [InlineData(0, 0.15, 0.372)]
-        [InlineData(0, 0.10, 0.248)]
-        [InlineData(1, 0.15, 0.272)]
-        [InlineData(1.5, 0.15, 0.222)]
-        [InlineData(1.5, 0.10, 0.148)]
+        [InlineData(0, 0.15, 0.37)]
+        [InlineData(0, 0.10, 0.25)]
+        [InlineData(1, 0.15, 0.27)]
+        [InlineData(1.5, 0.15, 0.22)]
+        [InlineData(1.5, 0.10, 0.15)]
         public void TestUpdateCalculatedValuesWithTaxExemptUpdatesTaxAmount(decimal discount, decimal taxPercent, decimal expectedValue)
         {
             // Arrange

--- a/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
@@ -183,9 +183,9 @@ namespace Payments.Tests.DatabaseTests
         {
             // Arrange
             var invoice = new Invoice();
-            invoice.Items.Add(new LineItem() { Total = 1.23m });
-            invoice.Items.Add(new LineItem() { Total = 1.24m });
-            invoice.Items.Add(new LineItem() { Total = 1.25m });
+            invoice.Items.Add(new LineItem() { Amount = 1.23m, Quantity = 1, Total = 1.23m });
+            invoice.Items.Add(new LineItem() { Amount = 1.24m, Quantity = 1, Total = 1.24m });
+            invoice.Items.Add(new LineItem() { Amount = 1.25m, Quantity = 1, Total = 1.25m });
 
 
             // Act
@@ -193,6 +193,23 @@ namespace Payments.Tests.DatabaseTests
 
             // Assert		
             invoice.CalculatedSubtotal.ShouldBe(3.72m);
+        }
+
+        [Fact]
+        public void TestUpdateCalculatedValuesUsesUnroundedLineItemTotals()
+        {
+            // Arrange
+            var invoice = new Invoice();
+            invoice.Items.Add(new LineItem() { Amount = 155.74m, Quantity = 0.06m, Total = 9.34m });
+            invoice.Items.Add(new LineItem() { Amount = 155.74m, Quantity = 0.06m, Total = 9.34m });
+            invoice.Items.Add(new LineItem() { Amount = 155.74m, Quantity = 0.06m, Total = 9.34m });
+
+            // Act
+            invoice.UpdateCalculatedValues();
+
+            // Assert
+            invoice.CalculatedSubtotal.ShouldBe(28.0332m);
+            invoice.CalculatedTotal.ShouldBe(28.03m);
         }
 
         [Theory]
@@ -209,9 +226,9 @@ namespace Payments.Tests.DatabaseTests
         {
             // Arrange
             var invoice = new Invoice();
-            invoice.Items.Add(new LineItem() { Total = 1.23m });
-            invoice.Items.Add(new LineItem() { Total = 1.24m });
-            invoice.Items.Add(new LineItem() { Total = 1.25m });
+            invoice.Items.Add(new LineItem() { Amount = 1.23m, Quantity = 1, Total = 1.23m });
+            invoice.Items.Add(new LineItem() { Amount = 1.24m, Quantity = 1, Total = 1.24m });
+            invoice.Items.Add(new LineItem() { Amount = 1.25m, Quantity = 1, Total = 1.25m });
             invoice.ManualDiscount = discount;
             invoice.TaxPercent = taxPercent;
 
@@ -235,9 +252,9 @@ namespace Payments.Tests.DatabaseTests
         {
             // Arrange
             var invoice = new Invoice();
-            invoice.Items.Add(new LineItem() { Total = 1.23m });
-            invoice.Items.Add(new LineItem() { Total = 1.24m, TaxExempt = true });
-            invoice.Items.Add(new LineItem() { Total = 1.25m });
+            invoice.Items.Add(new LineItem() { Amount = 1.23m, Quantity = 1, Total = 1.23m });
+            invoice.Items.Add(new LineItem() { Amount = 1.24m, Quantity = 1, Total = 1.24m, TaxExempt = true });
+            invoice.Items.Add(new LineItem() { Amount = 1.25m, Quantity = 1, Total = 1.25m });
             invoice.ManualDiscount = discount;
             invoice.TaxPercent = taxPercent;
 
@@ -262,9 +279,9 @@ namespace Payments.Tests.DatabaseTests
         {
             // Arrange
             var invoice = new Invoice();
-            invoice.Items.Add(new LineItem() { Total = 1.23m });
-            invoice.Items.Add(new LineItem() { Total = 1.24m });
-            invoice.Items.Add(new LineItem() { Total = 1.25m });
+            invoice.Items.Add(new LineItem() { Amount = 1.23m, Quantity = 1, Total = 1.23m });
+            invoice.Items.Add(new LineItem() { Amount = 1.24m, Quantity = 1, Total = 1.24m });
+            invoice.Items.Add(new LineItem() { Amount = 1.25m, Quantity = 1, Total = 1.25m });
             invoice.ManualDiscount = discount;
             invoice.TaxPercent = taxPercent;
 
@@ -288,9 +305,9 @@ namespace Payments.Tests.DatabaseTests
         {
             // Arrange
             var invoice = new Invoice();
-            invoice.Items.Add(new LineItem() { Total = 1.23m });
-            invoice.Items.Add(new LineItem() { Total = 1.24m, TaxExempt = true });
-            invoice.Items.Add(new LineItem() { Total = 1.25m });
+            invoice.Items.Add(new LineItem() { Amount = 1.23m, Quantity = 1, Total = 1.23m });
+            invoice.Items.Add(new LineItem() { Amount = 1.24m, Quantity = 1, Total = 1.24m, TaxExempt = true });
+            invoice.Items.Add(new LineItem() { Amount = 1.25m, Quantity = 1, Total = 1.25m });
             invoice.ManualDiscount = discount;
             invoice.TaxPercent = taxPercent;
 

--- a/tests/Payments.Tests/ServiceTests/InvoiceServiceTests.cs
+++ b/tests/Payments.Tests/ServiceTests/InvoiceServiceTests.cs
@@ -114,7 +114,7 @@ namespace payments.Tests.ServiceTests
                 ManualDiscount = 10,
                 Items = new List<LineItem>
                 {
-                    new LineItem { Total = 10 },
+                    new LineItem { Amount = 10, Quantity = 1, Total = 10 },
                 },
             };
             invoice.UpdateCalculatedValues();
@@ -152,7 +152,7 @@ namespace payments.Tests.ServiceTests
                 Coupon = new Coupon { DiscountAmount = 10 },
                 Items = new List<LineItem>
                 {
-                    new LineItem { Total = 10 },
+                    new LineItem { Amount = 10, Quantity = 1, Total = 10 },
                 },
             };
             invoice.UpdateCalculatedValues();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected invoice subtotal, discount, tax, and total calculations to account for item quantity and amount.
  * Tax amounts are now rounded to two decimal places before being included in invoice totals.
  * Improved calculation accuracy for coupons, taxable items, and tax-exempt items.

* **Tests**
  * Updated invoice and payment processing tests to verify quantity-based calculations and rounded tax results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->