### PR TITLE
Round each line item total before summing

### DIFF
--- a/src/Payments.Core/Domain/Invoice.cs
+++ b/src/Payments.Core/Domain/Invoice.cs
@@ -187,7 +187,7 @@ namespace Payments.Core.Domain
                 return Coupon.DiscountAmount ?? 0;
             }
 
-            var subTotal = Items.Sum(i => i.Quantity * i.Amount);
+            var subTotal = Items.Sum(i => LineItem.CalculateTotal(i.Quantity, i.Amount));
             if (Coupon.DiscountPercent.HasValue)
             {
                 return Coupon.DiscountPercent * subTotal ?? 0;
@@ -198,11 +198,16 @@ namespace Payments.Core.Domain
 
         public decimal GetTaxableTotal()
         {
-            var subtotal = Items.Sum(i => i.Quantity * i.Amount);
+            var subtotal = Items.Sum(i => LineItem.CalculateTotal(i.Quantity, i.Amount));
             var discount = GetDiscountAmount();
 
+            if (subtotal == 0)
+            {
+                return 0;
+            }
+
             // remove tax exempt items, apply proportional part of discount, then calculate tax
-            var taxableAmount = Items.Where(i => !i.TaxExempt).Sum(i => i.Quantity * i.Amount);
+            var taxableAmount = Items.Where(i => !i.TaxExempt).Sum(i => LineItem.CalculateTotal(i.Quantity, i.Amount));
             var taxableDiscount = discount * (taxableAmount / subtotal);
             return (taxableAmount - taxableDiscount);
         }
@@ -215,7 +220,12 @@ namespace Payments.Core.Domain
 
         public void UpdateCalculatedValues()
         {
-            CalculatedSubtotal = Items.Sum(i => i.Quantity * i.Amount);
+            foreach (var item in Items)
+            {
+                item.Total = LineItem.CalculateTotal(item.Quantity, item.Amount);
+            }
+
+            CalculatedSubtotal = Items.Sum(i => i.Total);
 
             CalculatedDiscount = GetDiscountAmount();
 
@@ -223,7 +233,6 @@ namespace Payments.Core.Domain
 
             CalculatedTaxAmount = GetTaxAmount();
 
-            //Now that we sum everything, now we round the total
             CalculatedTotal = Math.Round(Math.Max(CalculatedSubtotal - CalculatedDiscount + CalculatedTaxAmount, 0m), 2, MidpointRounding.AwayFromZero);
         }
 

--- a/src/Payments.Core/Domain/LineItem.cs
+++ b/src/Payments.Core/Domain/LineItem.cs
@@ -26,5 +26,10 @@ namespace Payments.Core.Domain
         public decimal Total { get; set; }
 
         public bool TaxExempt { get; set; }
+
+        public static decimal CalculateTotal(decimal quantity, decimal amount)
+        {
+            return Math.Round(quantity * amount, 2, MidpointRounding.AwayFromZero);
+        }
     }
 }

--- a/src/Payments.Mvc/ClientApp/src/components/editItemsTable.tsx
+++ b/src/Payments.Mvc/ClientApp/src/components/editItemsTable.tsx
@@ -6,6 +6,7 @@ import { InvoiceItem } from '../models/InvoiceItem';
 
 import {
   calculateDiscount,
+  calculateLineItemTotal,
   calculateSubTotal,
   calculateTaxAmount,
   calculateTotal
@@ -272,7 +273,7 @@ export default class EditItemsTable extends React.Component<IProps, IState> {
             </div>
           </div>
         </td>
-        <td>{formatCurrencyLocale(quantity * amount)}</td>
+        <td>{formatCurrencyLocale(calculateLineItemTotal(quantity, amount))}</td>
         <td>
           <button
             className='btn btn-danger btn-icon'
@@ -355,9 +356,8 @@ export default class EditItemsTable extends React.Component<IProps, IState> {
     const item = {
       ...this.state.items.byHash[id]
     };
-    item.total = item.amount * item.quantity;
-
     item[name] = value;
+    item.total = calculateLineItemTotal(item.quantity, item.amount);
     this.updateItem(id, item);
   };
 

--- a/src/Payments.Mvc/ClientApp/src/components/sendModal.tsx
+++ b/src/Payments.Mvc/ClientApp/src/components/sendModal.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import {
   calculateDiscount,
+  calculateLineItemTotal,
   calculateSubTotal,
   calculateTaxAmount,
   calculateTotal
@@ -145,7 +146,7 @@ export default class SendModal extends React.PureComponent<IProps, IState> {
           description: item.description,
           quantity: item.quantity,
           amount: item.amount,
-          total: item.amount * item.quantity
+          total: calculateLineItemTotal(item.quantity, item.amount)
         })),
         attachments: attachments.map((att, index) => ({
           id: index, // Use index as placeholder ID for preview

--- a/src/Payments.Mvc/ClientApp/src/helpers/calculations.test.ts
+++ b/src/Payments.Mvc/ClientApp/src/helpers/calculations.test.ts
@@ -1,5 +1,6 @@
 import {
   calculatePercentageAmount,
+  calculateSubTotal,
   calculateTaxAmount,
   calculateTotal,
   roundCurrency
@@ -9,7 +10,8 @@ describe('currency calculations', () => {
   it.each([
     [9.349, 9.35],
     [9.344, 9.34],
-    [9.345, 9.35]
+    [9.345, 9.35],
+    [-9.345, -9.35]
   ])('rounds %s to %s', (value, expected) => {
     expect(roundCurrency(value)).toBe(expected);
   });
@@ -38,27 +40,28 @@ describe('currency calculations', () => {
     }
   );
 
-  it('rounds the combined total after summing all line items', () => {
+  it('rounds each line item before summing', () => {
     const items = [
       {
         id: 1,
-        description: 'Recharge item',
-        quantity: 0.06,
-        amount: 155.83,
+        description: 'First item',
+        quantity: 0.5,
+        amount: 0.01,
         taxExempt: false,
         total: 0
       },
       {
         id: 2,
-        description: 'Rounding adjustment item',
-        quantity: 0.01,
-        amount: 0.02,
+        description: 'Second item',
+        quantity: 0.5,
+        amount: 0.01,
         taxExempt: false,
         total: 0
       }
     ];
 
-    expect(calculateTotal(items, { hasDiscount: false }, 0)).toBe(9.35);
+    expect(calculateSubTotal(items)).toBe(0.02);
+    expect(calculateTotal(items, { hasDiscount: false }, 0)).toBe(0.02);
   });
 
   it('rounds tax before calculating the invoice total', () => {
@@ -73,7 +76,22 @@ describe('currency calculations', () => {
     const discount = { hasDiscount: false };
 
     expect(calculateTaxAmount(items, discount, 0.07)).toBe(1.96);
-    expect(calculateTotal(items, discount, 0.07)).toBe(29.99);
+    expect(calculateTotal(items, discount, 0.07)).toBe(29.98);
+  });
+
+  it('returns zero tax when the subtotal is zero', () => {
+    const items = [
+      {
+        id: 1,
+        description: 'Zero amount item',
+        quantity: 0,
+        amount: 10,
+        taxExempt: false,
+        total: 0
+      }
+    ];
+
+    expect(calculateTaxAmount(items, { hasDiscount: false }, 0.07)).toBe(0);
   });
 
   it.each([

--- a/src/Payments.Mvc/ClientApp/src/helpers/calculations.ts
+++ b/src/Payments.Mvc/ClientApp/src/helpers/calculations.ts
@@ -14,9 +14,13 @@ export function calculatePercentageAmount(total: number, percentage: number) {
     return roundCurrency((percentage / 100) * total);
 }
 
+export function calculateLineItemTotal(quantity: number, amount: number) {
+    return roundCurrency(quantity * amount);
+}
+
 export function calculateSubTotal(items: InvoiceItem[]) {
     const sum = items.reduce((prev, item) => {
-        return prev + (item.quantity * item.amount);
+        return prev + calculateLineItemTotal(item.quantity, item.amount);
     }, 0);
 
     return sum;
@@ -28,7 +32,7 @@ export function calculateTaxableSubTotal(items: InvoiceItem[]) {
             return prev;
         }
 
-        return prev + (item.quantity * item.amount);
+        return prev + calculateLineItemTotal(item.quantity, item.amount);
     }, 0);
 
     return sum;
@@ -69,7 +73,7 @@ export function calculateTaxAmount(items: InvoiceItem[], discount: InvoiceDiscou
     const totalDiscount = calculateDiscount(items, discount);
 
     const taxableSub = calculateTaxableSubTotal(items);
-    if (taxableSub <= 0) {
+    if (sub === 0 || taxableSub <= 0) {
         return 0;
     }
 

--- a/src/Payments.Mvc/Controllers/InvoicesController.cs
+++ b/src/Payments.Mvc/Controllers/InvoicesController.cs
@@ -337,7 +337,7 @@ namespace Payments.Mvc.Controllers
                     Description = i.Description,
                     Quantity = i.Quantity,
                     TaxExempt = i.TaxExempt,
-                    Total = i.Amount * i.Quantity,
+                    Total = LineItem.CalculateTotal(i.Quantity, i.Amount),
                 }).ToList(),
                 Attachments = invoice.Attachments.Select(a => new EditInvoiceAttachmentModel()
                 {

--- a/src/Payments.Mvc/Services/InvoiceService.cs
+++ b/src/Payments.Mvc/Services/InvoiceService.cs
@@ -136,7 +136,7 @@ namespace Payments.Mvc.Services
                     Description = i.Description,
                     Quantity = i.Quantity,
                     TaxExempt = i.TaxExempt,
-                    Total = i.Quantity * i.Amount,
+                    Total = LineItem.CalculateTotal(i.Quantity, i.Amount),
                 });
                 invoice.Items = items.ToList();
 
@@ -290,7 +290,7 @@ namespace Payments.Mvc.Services
                 Description = i.Description,
                 Quantity = i.Quantity,
                 TaxExempt = i.TaxExempt,
-                Total = i.Quantity * i.Amount,
+                Total = LineItem.CalculateTotal(i.Quantity, i.Amount),
             });
             invoice.Items = items.ToList();
 
@@ -797,7 +797,7 @@ namespace Payments.Mvc.Services
                     Description = item.Description,
                     Quantity = item.Quantity,
                     Amount = item.Amount,
-                    Total = item.Total,
+                    Total = LineItem.CalculateTotal(item.Quantity, item.Amount),
                     TaxExempt = item.TaxExempt,                    
                 };
                 invoice.Items.Add(newItem);

--- a/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/InvoiceTests.cs
@@ -196,7 +196,7 @@ namespace Payments.Tests.DatabaseTests
         }
 
         [Fact]
-        public void TestUpdateCalculatedValuesUsesUnroundedLineItemTotalsAndRoundedTax()
+        public void TestUpdateCalculatedValuesRoundsEachLineItemBeforeSummingAndRoundsTax()
         {
             // Arrange
             var invoice = new Invoice();
@@ -209,9 +209,28 @@ namespace Payments.Tests.DatabaseTests
             invoice.UpdateCalculatedValues();
 
             // Assert
-            invoice.CalculatedSubtotal.ShouldBe(28.0332m);
+            invoice.CalculatedSubtotal.ShouldBe(28.02m);
+            invoice.Items.ShouldAllBe(i => i.Total == 9.34m);
             invoice.CalculatedTaxAmount.ShouldBe(1.96m);
-            invoice.CalculatedTotal.ShouldBe(29.99m);
+            invoice.CalculatedTotal.ShouldBe(29.98m);
+        }
+
+        [Fact]
+        public void TestUpdateCalculatedValuesDoesNotDivideByZeroWhenSubtotalIsZero()
+        {
+            // Arrange
+            var invoice = new Invoice();
+            invoice.Items.Add(new LineItem() { Amount = 10m, Quantity = 0m });
+            invoice.TaxPercent = 0.0725m;
+
+            // Act
+            invoice.UpdateCalculatedValues();
+
+            // Assert
+            invoice.CalculatedSubtotal.ShouldBe(0m);
+            invoice.CalculatedTaxableAmount.ShouldBe(0m);
+            invoice.CalculatedTaxAmount.ShouldBe(0m);
+            invoice.CalculatedTotal.ShouldBe(0m);
         }
 
         [Theory]

--- a/tests/Payments.Tests/DatabaseTests/LineItemTests.cs
+++ b/tests/Payments.Tests/DatabaseTests/LineItemTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Payments.Core.Domain;
+using Shouldly;
 using TestHelpers.Helpers;
 using Xunit;
 
@@ -43,6 +44,14 @@ namespace Payments.Tests.DatabaseTests
             #endregion Arrange
 
             AttributeAndFieldValidation.ValidateFieldsAndAttributes(expectedFields, typeof(LineItem));
+        }
+
+        [Theory]
+        [InlineData(0.5, 0.01, 0.01)]
+        [InlineData(0.5, -0.01, -0.01)]
+        public void CalculateTotalRoundsMidpointsAwayFromZero(decimal quantity, decimal amount, decimal expected)
+        {
+            LineItem.CalculateTotal(quantity, amount).ShouldBe(expected);
         }
     }
 }


### PR DESCRIPTION
Previously, line item totals (quantity * amount) were sometimes calculated and summed without consistent rounding, leading to potential discrepancies in total invoice calculations.

This change introduces a dedicated `CalculateTotal` method for line items (both C# and TypeScript) that rounds the product of quantity and amount to two decimal places *before* summing for subtotal, taxable total, and other invoice calculations. This ensures consistent currency rounding at the line item level.

Additionally, it adds a check to prevent division by zero in tax calculations when the subtotal is zero. This aligns calculations with common accounting practices for currency precision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved invoice accuracy by rounding each line-item total to two decimal places before calculating subtotals, taxes, discounts, and totals.
  * Applied consistent rounding across invoice creation, editing, copying, and preview workflows.
  * Prevented tax calculations from dividing by zero when the invoice subtotal is zero.
  * Added correct midpoint rounding for both positive and negative amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->